### PR TITLE
Fixed compilation error with V8 version 5.2.327+

### DIFF
--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -226,22 +226,22 @@ private:
 		if (destroy_after)
 		{
 			pobj.SetWeak(object,
-				[](v8::WeakCallbackData<v8::Object, T> const& data)
+				[](v8::WeakCallbackInfo<T> const& data)
 			{
 				v8::Isolate* isolate = data.GetIsolate();
 				T* object = data.GetParameter();
 				instance(isolate).destroy_object(object);
-			});
+			}, v8::WeakCallbackType::kFinalizer);
 		}
 		else
 		{
 			pobj.SetWeak(object,
-				[](v8::WeakCallbackData<v8::Object, T> const& data)
+				[](v8::WeakCallbackInfo<T> const& data)
 			{
 				v8::Isolate* isolate = data.GetIsolate();
 				T* object = data.GetParameter();
 				instance(isolate).remove_object(isolate, object);
-			});
+			}, v8::WeakCallbackType::kFinalizer);
 
 		}
 

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -57,10 +57,10 @@ set_external_data(v8::Isolate* isolate, T const& value)
 	v8::Local<v8::External> ext = v8::External::New(isolate, data);
 
 	v8::Persistent<v8::External> pext(isolate, ext);
-	pext.SetWeak(data, [](v8::WeakCallbackData<v8::External, T> const& data)
+	pext.SetWeak(data, [](v8::WeakCallbackInfo<T> const& data)
 		{
 			delete data.GetParameter();
-		});
+		}, v8::WeakCallbackType::kFinalizer);
 
 	return ext;
 }


### PR DESCRIPTION
As of https://github.com/v8/v8/commit/82dcb2beeeb85369902c76e48374caed4fac58fb V8 has removed a deprecated WeakCallbackData. This commit replaces the deprecated type with WeakCallbackInfo. This fixes the compilation error with newer versions of V8.