### PR TITLE
Exported v8::ArrayBuffer::Allocator as an optional v8pp::context parameter

### DIFF
--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -160,13 +160,13 @@ struct array_buffer_allocator : v8::ArrayBuffer::Allocator
 };
 static array_buffer_allocator array_buffer_allocator_;
 
-context::context(v8::Isolate* isolate)
+context::context(v8::Isolate* isolate, v8::ArrayBuffer::Allocator* allocator)
 {
 	own_isolate_ = (isolate == nullptr);
 	if (own_isolate_)
 	{
 		v8::Isolate::CreateParams create_params;
-		create_params.array_buffer_allocator = &array_buffer_allocator_;
+		create_params.array_buffer_allocator = allocator ? allocator : &array_buffer_allocator_;
 
 		isolate = v8::Isolate::New(create_params);
 		isolate->Enter();

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -28,7 +28,7 @@ class context
 {
 public:
 	/// Create context with optional existing v8::Isolate
-	explicit context(v8::Isolate* isolate = nullptr);
+	explicit context(v8::Isolate* isolate = nullptr, v8::ArrayBuffer::Allocator* allocator = nullptr);
 	~context();
 
 	/// V8 isolate associated with this context


### PR DESCRIPTION
To be able to use a different v8::ArrayBuffer::Allocator export the pointer as an optional v8pp::context parameter