### PR TITLE
Allow to assign generic function with `v8::FunctionCallbackInfo` as a class ctor to handle overloads.

### DIFF
--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -431,6 +431,12 @@ public:
 		return to_local(isolate_, js_func_.IsEmpty()? func_ : js_func_);
 	}
 
+	void ctor(T* (*f)(v8::FunctionCallbackInfo<v8::Value> const& args))
+	{
+		ctor_ = f;
+		class_function_template()->Inherit(js_function_template());
+	}
+
 	template<typename ...Args>
 	void ctor()
 	{
@@ -534,6 +540,12 @@ public:
 	}
 
 	/// Set class constructor signature
+	class_& ctor(T* (*f)(v8::FunctionCallbackInfo<v8::Value> const& args))
+	{
+		class_singleton_.ctor(f);
+		return *this;
+	}
+	
 	template<typename ...Args>
 	class_& ctor()
 	{


### PR DESCRIPTION

fixes #41