### PR TITLE
Mitigate electron DevTools console crashes

### DIFF
--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -729,9 +729,16 @@ private:
 	{
 		v8::Isolate* isolate = info.GetIsolate();
 
-		T const& self = v8pp::from_v8<T const&>(isolate, info.This());
-		Attribute attr = detail::get_external_data<Attribute>(info.Data());
-		info.GetReturnValue().Set(to_v8(isolate, self.*attr));
+                try
+                  {
+                    T const& self = v8pp::from_v8<T const&>(isolate, info.This());
+                    Attribute attr = detail::get_external_data<Attribute>(info.Data());
+                    info.GetReturnValue().Set(to_v8(isolate, self.*attr));
+                  }
+                catch (std::exception const& ex)
+                  {
+                    info.GetReturnValue().Set(throw_ex(isolate, ex.what()));
+                  }
 	}
 
 	template<typename Attribute>
@@ -740,10 +747,17 @@ private:
 	{
 		v8::Isolate* isolate = info.GetIsolate();
 
-		T& self = v8pp::from_v8<T&>(isolate, info.This());
-		Attribute ptr = detail::get_external_data<Attribute>(info.Data());
-		using attr_type = typename detail::function_traits<Attribute>::return_type;
-		self.*ptr = v8pp::from_v8<attr_type>(isolate, value);
+                try
+                  {
+                    T& self = v8pp::from_v8<T&>(isolate, info.This());
+                    Attribute ptr = detail::get_external_data<Attribute>(info.Data());
+                    using attr_type = typename detail::function_traits<Attribute>::return_type;
+                    self.*ptr = v8pp::from_v8<attr_type>(isolate, value);
+                  }
+                catch (std::exception const& ex)
+                  {
+                    info.GetReturnValue().Set(throw_ex(isolate, ex.what()));
+                  }
 	}
 };
 

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -578,14 +578,14 @@ struct convert<T, typename std::enable_if<is_wrapped_class<T>::value>::type>
 		{
 			return *object;
 		}
-		throw std::runtime_error("expected C++ wrapped object");
+		throw std::runtime_error("failed to unwrap C++ object");
 	}
 
 	static to_type to_v8(v8::Isolate* isolate, T const& value)
 	{
 		v8::Handle<v8::Object> result = convert<T*>::to_v8(isolate, &value);
 		if (!result.IsEmpty()) return result;
-		throw std::runtime_error("expected C++ wrapped object");
+		throw std::runtime_error("failed to wrap C++ object");
 	}
 };
 

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -134,14 +134,13 @@ struct r_property_impl<Get, Set, true>
 	{
 		v8::Isolate* isolate = info.GetIsolate();
 
-		class_type& obj = v8pp::from_v8<class_type&>(isolate, info.This());
-
-		Property const& prop = detail::get_external_data<Property>(info.Data());
-		assert(prop.get_);
-
-		if (prop.get_)
 		try
 		{
+		      class_type& obj = v8pp::from_v8<class_type&>(isolate, info.This());
+
+		      Property const& prop = detail::get_external_data<Property>(info.Data());
+
+		      if (prop.get_)
 			get_impl(obj, prop.get_, name, info, select_getter_tag<Get>());
 		}
 		catch (std::exception const& ex)


### PR DESCRIPTION
As described in issue #52, turning C++ exceptions thrown from invalid property accesses into V8 exceptions can keep the electron v1.4.15 console from crashing. That is what this PR accomplishes.