### PR TITLE
Fixed template parameter redefines default argument on clang++

### DIFF
--- a/v8pp/ptr_traits.hpp
+++ b/v8pp/ptr_traits.hpp
@@ -13,7 +13,7 @@
 
 namespace v8pp {
 
-template<typename T, typename Enable = void>
+template<typename T, typename Enable>
 struct convert;
 
 struct raw_ptr_traits


### PR DESCRIPTION
using version on MacOS with LLVM 10.0.0

it prevents me from compiling if the default argument is specified twice

see https://stackoverflow.com/questions/14197436/c11-template-parameter-redefines-default-argument