### PR TITLE
Use v8::Local handles everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The library is suitable to make [Node.js](http://nodejs.org/) and [io.js](https:
 
 ```c++
 
-void RegisterModule(v8::Handle<v8::Object> exports)
+void RegisterModule(v8::Local<v8::Object> exports)
 {
     v8pp::module addon(v8::Isolate::GetCurrent());
 
@@ -122,7 +122,7 @@ void log(v8::FunctionCallbackInfo<v8::Value> const& args)
     std::cout << std::endl;
 }
 
-v8::Handle<v8::Value> init(v8::Isolate* isolate)
+v8::Local<v8::Value> init(v8::Isolate* isolate)
 {
     v8pp::module m(isolate);
     m.set("log", &log);
@@ -219,7 +219,7 @@ public:
         return stream_.good();
     }
 
-    v8::Handle<v8::Value> getline(v8::Isolate* isolate)
+    v8::Local<v8::Value> getline(v8::Isolate* isolate)
     {
         if ( stream_.good() && ! stream_.eof())
         {
@@ -234,7 +234,7 @@ public:
     }
 };
 
-v8::Handle<v8::Value> init(v8::Isolate* isolate)
+v8::Local<v8::Value> init(v8::Isolate* isolate)
 {
     v8::EscapableHandleScope scope(isolate);
 
@@ -326,7 +326,7 @@ console.log("exit")
 // Memory for C++ class will remain when JavaScript object is deleted.
 // Useful for classes you only wish to inject.
 typedef v8pp::class_<my_class> my_class_wrapper(isolate);
-v8::Handle<v8::Value> val = my_class_wrapper::reference_external(&my_class::instance());
+v8::Local<v8::Value> val = my_class_wrapper::reference_external(&my_class::instance());
 // Assuming my_class::instance() returns reference to class
 ```
 
@@ -336,7 +336,7 @@ v8::Handle<v8::Value> val = my_class_wrapper::reference_external(&my_class::inst
 // Memory for c++ object will be reclaimed by JavaScript using "delete" when
 // JavaScript class is deleted.
 typedef v8pp::class_<my_class> my_class_wrapper(isolate);
-v8::Handle<v8::Value> val = my_class_wrapper::import_external(new my_class);
+v8::Local<v8::Value> val = my_class_wrapper::import_external(new my_class);
 ```
 
 ## Compile-time configuration

--- a/docs/convert.md
+++ b/docs/convert.md
@@ -15,13 +15,13 @@ v8::Local<v8::Value>  v8_int = v8pp::to_v8(isolate, 42);
 v8::Local<v8::String> v8_str = v8pp::to_v8(isolate, "hello");
 ```
 
-The opposite function template `v8pp::from_v8<T>(v8::Isolate*, v8::Handle<v8::Value> value)`
+The opposite function template `v8pp::from_v8<T>(v8::Isolate*, v8::Local<v8::Value> value)`
 converts a V8 value to a C++ value of explicitly declared type `T`.
 
 If source V8 value is empty or not convertible to the specified C++ type,
 a `std::invalid_argument` exception would be thrown.
 
-An overloaded function `v8pp::from_v8<T>(v8::Isolate*, v8::Handle<v8::Value>, T const& default_value)`
+An overloaded function `v8pp::from_v8<T>(v8::Isolate*, v8::Local<v8::Value>, T const& default_value)`
 converts a V8 value or returns `default_value` on conversion error.
 
 ```c++
@@ -142,13 +142,13 @@ struct convert
 	using from_type = T;
 
 	// V8 return type for v8pp::to_v8() function
-	using to_type = v8::Handle<v8::Value>;
+	using to_type = v8::Local<v8::Value>;
 
 	// Is V8 value valid to convert from?
-	static bool is_valid(v8::Isolate* isolate, v8::Handle<v8::Value> value);
+	static bool is_valid(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
 	// Convert V8 value to C++
-	static from_type from_v8(v8::Isolate* isolate, v8::Handle<v8::Value> value);
+	static from_type from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value);
 
 	// Convert C++ value to V8
 	static to_type to_v8(v8::Isolate* isolate, T const& value);
@@ -168,15 +168,15 @@ template<>
 struct v8pp::convert<Vector3>
 {
 	using from_type = Vector3;
-	using to_type = v8::Handle<v8::Array>;
+	using to_type = v8::Local<v8::Array>;
 
-	static bool is_valid(v8::Isolate*, v8::Handle<v8::Value> value)
+	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
 	{
 		return !value.IsEmpty() && value->IsArray()
 			&& value.As<v8::Array>()->Length() == 3;
 	}
 
-	static from_type from_v8(v8::Isolate* isolate, v8::Handle<v8::Value> value)
+	static from_type from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value)
 	{
 		if (!is_valid(isolate, value))
 		{
@@ -228,15 +228,15 @@ template<typename T>
 struct v8pp::convert<Vector3<T>>
 {
 	using from_type = Vector3<T>;
-	using to_type = v8::Handle<v8::Array>;
+	using to_type = v8::Local<v8::Array>;
 
-	static bool is_valid(v8::Isolate*, v8::Handle<v8::Value> value)
+	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
 	{
 		return !value.IsEmpty() && value->IsArray()
 			&& value.As<v8::Array>()->Length() == 3;
 	}
 
-	static from_type from_v8(v8::Isolate* isolate, v8::Handle<v8::Value> value)
+	static from_type from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value)
 	{
 		if (!is_valid(isolate, value))
 		{

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -10,7 +10,7 @@ function templates for these tasks.
 
 ### Get an attribute from V8 object
 
-Function `bool v8pp::get_option(v8::Isolate* isolate, v8::Handle<v8::Object> object, const* name, T& value)`
+Function `bool v8pp::get_option(v8::Isolate* isolate, v8::Local<v8::Object> object, const* name, T& value)`
 allows to get an optional C++ `value` from a V8 `object` by `name`. Symbols
 `.` in the `name` delimit sub-object names.
 
@@ -18,7 +18,7 @@ The functon returns `false` if there is no such named value in the `options`.
 
 ```c++
 v8::Isolate* isolate = v8::Isolate::GetCurrent();
-v8::Handle<v8::Object> object; // some object, say from JavaScript code
+v8::Local<v8::Object> object; // some object, say from JavaScript code
 
 bool flag = true;
 int var;
@@ -40,20 +40,20 @@ v8pp::get_option(isolate, object, "some", some);
 
 ### Set an attribute in V8 object
 
-Function `bool v8pp::set_option(v8::Isolate* isolate, v8::Handle<v8::Object> object,  const* name, T const& value)`
+Function `bool v8pp::set_option(v8::Isolate* isolate, v8::Local<v8::Object> object,  const* name, T const& value)`
 sets a C++ `value` in a V8 `object` by `name`. Symbols `.` in the `name`
 delimit sub-object names.
 
 The function returns `false` if there is no such named value in the `options`.
 
-Function `void v8pp::set_const(v8::Isolate* isolate, v8::Handle<v8::Object> object, char const* name, T const& value)`
+Function `void v8pp::set_const(v8::Isolate* isolate, v8::Local<v8::Object> object, char const* name, T const& value)`
 sets a constant C++ `value` in a V8 `object` by `name`. 
 
 Note this function doesn't support sub-object names.
 
 ```c++
 v8::Isolate* isolate = v8::Isolate::GetCurrent();
-v8::Handle<v8::Object> object = v8::Object::New(isolate);
+v8::Local<v8::Object> object = v8::Object::New(isolate);
 
 v8pp::set_option(isolate, object, "flag", true);
 
@@ -82,10 +82,10 @@ Header file [`v8pp/json.hpp`](../v8pp/json.hpp) contains a pair of functions
 for JSON manipulation.
 
 To stringify a V8 value to JSON use function
-`std::string v8pp::json_str(v8::Isolate* isolate, v8::Handle<v8::Value> value)` 
+`std::string v8pp::json_str(v8::Isolate* isolate, v8::Local<v8::Value> value)`
 
 To parse a JSON string to V8 value use function
-`v8::Handle<v8::Value> v8pp::json_parse(v8::Isolate* isolate, std::string const& str)`
+`v8::Local<v8::Value> v8pp::json_parse(v8::Isolate* isolate, std::string const& str)`
 
 ```c++
 v8::Isolate* isolate = v8::Isolate::GetCurrent();
@@ -101,7 +101,7 @@ v8::Local<v8::Value> arr = v8pp::json_parse(isolate, R"([ 1, 2, 3 ])");
 ## Functions
 
 To call a `v8::Function` with arbitrary number of arguments use
-`v8::Handle<v8::Value> call_v8(v8::Isolate* isolate, v8::Handle<v8::Function> func, v8::Handle<v8::Value> recv, Args... args)`
+`v8::Local<v8::Value> call_v8(v8::Isolate* isolate, v8::Local<v8::Function> func, v8::Local<v8::Value> recv, Args... args)`
 function from [`v8pp/call_v8.hpp`](../v8pp/call_v8.hpp) header file.
 
 This function converts supplied arguments to V8 values using `v8pp::to_v8()`

--- a/docs/wrapping.md
+++ b/docs/wrapping.md
@@ -6,7 +6,7 @@ and `v8::FunctionTemplate` to call C++ functions from JavaScript.
 ## Wrapping C++ functions
 
 To create a new `v8::FunctionTemplate` for an arbitrary C++ function `func`
-use a function template `v8::Handle<v8::FunctionTemplate> v8pp::wrap_function_template(v8::Isolate* isolate, F func)`
+use a function template `v8::Local<v8::FunctionTemplate> v8pp::wrap_function_template(v8::Isolate* isolate, F func)`
 
 When a function generated from such a function template is being invoked in
 JavaScript, all function arguments will be converted from `v8::Value`s to
@@ -17,7 +17,7 @@ that returns `void` a `v8::Undefined` will be returned.
 If the wrapped C++ function throws an exception, a `v8::Exception::Error` will
 be returned into calling JavaScript code.
 
-A function `v8::Handle<v8::Function> v8pp::wrap_function(v8::Isolate* isolate, char const* name, F func)`
+A function `v8::Local<v8::Function> v8pp::wrap_function(v8::Isolate* isolate, char const* name, F func)`
 is used to wrap a C++ function to a `v8::Function` value. The V8 function will
 be created as anonymous when `nullptr` or `""` string literal is supplied for
 its `name`:

--- a/examples/01 hello world/hello.cc
+++ b/examples/01 hello world/hello.cc
@@ -15,7 +15,7 @@ char const* Method() {
   return "world";
 }
 
-void init(Handle<Object> exports) {
+void init(Local<Object> exports) {
   v8pp::module addon(Isolate::GetCurrent());
   addon.set("hello", &Method);
   exports->SetPrototype(Isolate::GetCurrent()->GetCurrentContext(), addon.new_instance());

--- a/examples/02 arguments/addon.cc
+++ b/examples/02 arguments/addon.cc
@@ -15,7 +15,7 @@ double Add(double arg1, double arg2) {
   return arg1 + arg2;
 }
 
-void Init(Handle<Object> exports) {
+void Init(Local<Object> exports) {
   v8pp::module addon(Isolate::GetCurrent());
   addon.set("add", &Add);
   exports->SetPrototype(Isolate::GetCurrent()->GetCurrentContext(), addon.new_instance());

--- a/examples/03 callbacks/addon.cc
+++ b/examples/03 callbacks/addon.cc
@@ -20,7 +20,7 @@ void RunCallback(Local<Function> cb) {
   v8pp::call_v8(isolate, cb, isolate->GetCurrentContext()->Global(), "hello world");
 }
 
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Local<Object> exports, Local<Object> module) {
   Isolate* isolate = Isolate::GetCurrent();
   v8pp::set_option(isolate, module, "exports", v8pp::wrap_function(isolate, "exports", &RunCallback));
 }

--- a/examples/04 object factory/addon.cc
+++ b/examples/04 object factory/addon.cc
@@ -14,7 +14,7 @@
 
 using namespace v8;
 
-Handle<Object> CreateObject(v8::Isolate* isolate, std::string const& msg) {
+Local<Object> CreateObject(v8::Isolate* isolate, std::string const& msg) {
   EscapableHandleScope scope(isolate);
 
   Local<Object> obj = Object::New(isolate);
@@ -22,7 +22,7 @@ Handle<Object> CreateObject(v8::Isolate* isolate, std::string const& msg) {
   return scope.Escape(obj);
 }
 
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Local<Object> exports, Local<Object> module) {
   Isolate* isolate = Isolate::GetCurrent();
   v8pp::set_option(isolate, module, "exports", v8pp::wrap_function(isolate, "exports", &CreateObject));
 }

--- a/examples/05 function factory/addon.cc
+++ b/examples/05 function factory/addon.cc
@@ -16,7 +16,7 @@ std::string MyFunction() {
   return "hello world";
 }
 
-Handle<Function> CreateFunction(Isolate* isolate) {
+Local<Function> CreateFunction(Isolate* isolate) {
   EscapableHandleScope scope(isolate);
 
   Local<FunctionTemplate> tpl = v8pp::wrap_function_template(isolate, &MyFunction);
@@ -27,7 +27,7 @@ Handle<Function> CreateFunction(Isolate* isolate) {
   return scope.Escape(fn);
 }
 
-void Init(Handle<Object> exports, Handle<Object> module) {
+void Init(Local<Object> exports, Local<Object> module) {
   Isolate* isolate = Isolate::GetCurrent();
   v8pp::set_option(isolate, module, "exports", v8pp::wrap_function(isolate, "exports", &CreateFunction));
 }

--- a/examples/06 wrapped objects/addon.cc
+++ b/examples/06 wrapped objects/addon.cc
@@ -11,7 +11,7 @@
 
 using namespace v8;
 
-void InitAll(Handle<Object> exports) {
+void InitAll(Local<Object> exports) {
   MyObject::Init(exports);
 }
 

--- a/examples/06 wrapped objects/myobject.cc
+++ b/examples/06 wrapped objects/myobject.cc
@@ -13,7 +13,7 @@
 
 using namespace v8;
 
-void MyObject::Init(Handle<Object> exports) {
+void MyObject::Init(Local<Object> exports) {
   Isolate* isolate = Isolate::GetCurrent();
 
   // Prepare class binding

--- a/examples/06 wrapped objects/myobject.h
+++ b/examples/06 wrapped objects/myobject.h
@@ -13,7 +13,7 @@
 
 class MyObject {
  public:
-  static void Init(v8::Handle<v8::Object> exports);
+  static void Init(v8::Local<v8::Object> exports);
 
   explicit MyObject(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/examples/07 wrapped objects factory/addon.cc
+++ b/examples/07 wrapped objects factory/addon.cc
@@ -15,12 +15,12 @@
 
 using namespace v8;
 
-static Handle<Object> CreateObject(const FunctionCallbackInfo<Value>& args) {
+static Local<Object> CreateObject(const FunctionCallbackInfo<Value>& args) {
   MyObject* obj = new MyObject(args);
   return v8pp::class_<MyObject>::import_external(args.GetIsolate(), obj);
 }
 
-void InitAll(Handle<Object> exports, Handle<Object> module) {
+void InitAll(Local<Object> exports, Local<Object> module) {
   MyObject::Init();
 
   Isolate* isolate = Isolate::GetCurrent();

--- a/examples/08 passing wrapped objects/addon.cc
+++ b/examples/08 passing wrapped objects/addon.cc
@@ -16,7 +16,7 @@
 
 using namespace v8;
 
-Handle<Object> CreateObject(const FunctionCallbackInfo<Value>& args) {
+Local<Object> CreateObject(const FunctionCallbackInfo<Value>& args) {
   MyObject* obj = new MyObject(args);
   return v8pp::class_<MyObject>::import_external(args.GetIsolate(), obj);
 }
@@ -25,7 +25,7 @@ double Add(MyObject const& obj1, MyObject const& obj2) {
   return obj1.value() + obj2.value();
 }
 
-void InitAll(Handle<Object> exports) {
+void InitAll(Local<Object> exports) {
   Isolate* isolate = Isolate::GetCurrent();
 
   v8pp::class_<MyObject> MyObject_class(isolate);

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -647,13 +647,13 @@ v8::Local<v8::String> to_v8(v8::Isolate* isolate,
 	return convert<char const*>::to_v8(isolate, str, len);
 }
 
-inline v8::Handle<v8::String> to_v8(v8::Isolate* isolate, char16_t const* str, size_t len)
+inline v8::Local<v8::String> to_v8(v8::Isolate* isolate, char16_t const* str, size_t len)
 {
 	return convert<char16_t const*>::to_v8(isolate, str, len);
 }
 
 template<size_t N>
-v8::Handle<v8::String> to_v8(v8::Isolate* isolate,
+v8::Local<v8::String> to_v8(v8::Isolate* isolate,
 	char16_t const (&str)[N], size_t len = N - 1)
 {
 	return convert<char16_t const*>::to_v8(isolate, str, len);

--- a/v8pp/persistent.hpp
+++ b/v8pp/persistent.hpp
@@ -32,7 +32,7 @@ struct persistent : public v8::Global<T>
 	}
 
 	template<typename S>
-	persistent(v8::Isolate* isolate, v8::Handle<S> const& handle)
+	persistent(v8::Isolate* isolate, v8::Local<S> const& handle)
 		: base_class(isolate, handle)
 	{
 	}


### PR DESCRIPTION
Fix the remaining v8::Handle occourances, including the docs & examples, so users are not mislead into using deprecated/removed types.