### PR TITLE
Support for members with accessors in class_

### DIFF
--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -283,7 +283,7 @@ public:
 		return *this;
 	}
 
-		/// Set read/write class property with getter and setter
+	/// Set read/write class property with getter and setter
 	template<typename GetMethod, typename SetMethod>
 	typename std::enable_if<std::is_member_function_pointer<GetMethod>::value
 		&& std::is_member_function_pointer<SetMethod>::value, class_&>::type

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -260,7 +260,7 @@ public:
 	/// Set class member data
 	template<typename Attribute>
 	typename std::enable_if<
-	        std::is_member_object_pointer<Attribute>::value, class_&>::type
+		std::is_member_object_pointer<Attribute>::value, class_&>::type
 	set(char const *name, Attribute attribute, bool readonly = false)
 	{
 		v8::HandleScope scope(isolate());
@@ -283,7 +283,7 @@ public:
 		return *this;
 	}
 
-    /// Set read/write class property with getter and setter
+		/// Set read/write class property with getter and setter
 	template<typename GetMethod, typename SetMethod>
 	typename std::enable_if<std::is_member_function_pointer<GetMethod>::value
 		&& std::is_member_function_pointer<SetMethod>::value, class_&>::type
@@ -296,8 +296,6 @@ public:
 			typename detail::function_traits<SetMethod>::template pointer_type<T>
 		>;
 		property_type prop(property);
-
-		// Need to generate one that chains property getter with the member getter below
 		v8::AccessorGetterCallback getter = property_type::template get<Traits>;
 		v8::AccessorSetterCallback setter = property_type::template set<Traits>;
 		if (prop.is_readonly)

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -260,7 +260,7 @@ public:
 	/// Set class member data
 	template<typename Attribute>
 	typename std::enable_if<
-		std::is_member_object_pointer<Attribute>::value, class_&>::type
+	        std::is_member_object_pointer<Attribute>::value, class_&>::type
 	set(char const *name, Attribute attribute, bool readonly = false)
 	{
 		v8::HandleScope scope(isolate());
@@ -283,7 +283,7 @@ public:
 		return *this;
 	}
 
-	/// Set read/write class property with getter and setter
+    /// Set read/write class property with getter and setter
 	template<typename GetMethod, typename SetMethod>
 	typename std::enable_if<std::is_member_function_pointer<GetMethod>::value
 		&& std::is_member_function_pointer<SetMethod>::value, class_&>::type
@@ -296,6 +296,8 @@ public:
 			typename detail::function_traits<SetMethod>::template pointer_type<T>
 		>;
 		property_type prop(property);
+
+		// Need to generate one that chains property getter with the member getter below
 		v8::AccessorGetterCallback getter = property_type::template get<Traits>;
 		v8::AccessorSetterCallback setter = property_type::template set<Traits>;
 		if (prop.is_readonly)
@@ -311,9 +313,65 @@ public:
 		return *this;
 	}
 
+	template<typename Attribute, typename GetMethod, typename SetMethod>
+	typename std::enable_if<std::is_member_pointer<Attribute>::value
+        && std::is_member_function_pointer<GetMethod>::value
+        && std::is_member_function_pointer<SetMethod>::value, class_&>::type
+     set(char const *name, member_property_<Attribute, GetMethod, SetMethod> &&property) {
+        using attribute_type = typename
+        detail::function_traits<Attribute>::template pointer_type<T>;
+
+        using property_type = member_property_<
+                Attribute,
+                GetMethod,
+                SetMethod
+                //typename detail::function_traits<GetMethod>::template pointer_type<>,
+                //typename detail::function_traits<SetMethod>::template pointer_type<>
+        >;
+        property_type prop(property);
+        v8::AccessorGetterCallback getter = property_type::template get<Traits>;
+        v8::AccessorSetterCallback setter = property_type::template set<Traits>;
+
+        if (prop.is_readonly)
+        {
+            setter = nullptr;
+        }
+
+        class_info_.class_function_template()->PrototypeTemplate()
+                ->SetAccessor(v8pp::to_v8(isolate(), name), getter, setter,
+                              detail::set_external_data(isolate(),
+                                                        std::forward<property_type>(prop)), v8::DEFAULT,
+                              v8::PropertyAttribute(v8::DontDelete | (setter ? 0 : v8::ReadOnly)));
+        return *this;
+
+	}
+
+    /// Set class member data
+    template<typename Attribute>
+    typename std::enable_if<
+            std::is_member_object_pointer<Attribute>::value, class_&>::type
+    set_const(char const *name, Attribute attribute)
+    {
+        v8::HandleScope scope(isolate());
+
+        using attribute_type = typename
+        detail::function_traits<Attribute>::template pointer_type<T>;
+        attribute_type attr(attribute);
+        v8::AccessorGetterCallback getter = &member_get<attribute_type>;
+
+        class_info_.class_function_template()->PrototypeTemplate()
+                ->SetAccessor(v8pp::to_v8(isolate(), name), getter, nullptr,
+                              detail::set_external_data(isolate(),
+                                                        std::forward<attribute_type>(attr)), v8::DEFAULT,
+                              v8::PropertyAttribute(v8::DontDelete |  v8::ReadOnly));
+        return *this;
+    }
+
 	/// Set value as a read-only property
 	template<typename Value>
-	class_& set_const(char const* name, Value const& value)
+    typename std::enable_if<
+            !std::is_member_object_pointer<Value>::value, class_&>::type
+	set_const(char const* name, Value const& value)
 	{
 		v8::HandleScope scope(isolate());
 

--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -273,4 +273,10 @@ v8::Local<v8::Value> context::run_script(std::string const& source,
 	return scope.Escape(result);
 }
 
+	v8::Local<v8::Context> context::impl() {
+		v8::EscapableHandleScope handleScope(isolate_);
+		v8::Local<v8::Context> ret = v8::Local<v8::Context>::New(isolate_, impl_);
+		return handleScope.Escape(ret);
+	}
+
 } // namespace v8pp

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -68,6 +68,8 @@ public:
 		return set(name, cl.js_function_template()->GetFunction(isolate_->GetCurrentContext()).ToLocalChecked());
 	}
 
+	v8::Local<v8::Context> impl();
+
 private:
 	bool own_isolate_;
 	v8::Isolate* isolate_;

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -371,7 +371,6 @@ struct rw_member_property {
 					v8::PropertyCallbackInfo<v8::Value> const& info)
 	try
 	{
-	    static_assert(std::is_member_pointer<Attribute>::value,"XXX");
 		auto obj = v8pp::class_<class_type, Traits>::unwrap_object(info.GetIsolate(), info.This());
 		assert(obj);
 

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -19,6 +19,9 @@ namespace v8pp {
 template<typename Get, typename Set>
 struct property_;
 
+template<typename Attribute, typename Get, typename Set>
+struct member_property_;
+
 namespace detail {
 
 struct getter_tag {};
@@ -52,6 +55,14 @@ using is_isolate_getter = std::integral_constant<bool,
 template<typename F>
 using is_setter = std::integral_constant<bool,
 	call_from_v8_traits<F>::arg_count == 1 && is_void_return<F>::value>;
+
+template<typename F>
+using is_loose_setter = std::integral_constant<bool,
+    call_from_v8_traits<F>::arg_count == 1 &&
+    std::is_member_function_pointer<F>::value &&
+    std::is_same<
+            typename std::decay<typename function_traits<F>::return_type>::type,
+            typename std::decay<typename std::tuple_element<0, typename function_traits<F>::arguments>::type>::type>::value>;
 
 template<typename F>
 using is_direct_setter = std::integral_constant<bool,
@@ -318,6 +329,115 @@ struct rw_property_impl<Get, Set, false>
 	}
 };
 
+template <typename Attribute, typename Get, typename Set>
+struct rw_member_property {
+	using property_type = member_property_<Attribute, Get, Set>;
+
+	using class_type = typename std::decay<typename std::tuple_element<0,
+			typename function_traits<Attribute>::arguments> ::type>::type;
+
+    static_assert(std::is_member_pointer<Attribute>::value, "member property must be `&T::member`");
+
+    static_assert(is_getter<Get>::value
+				  || is_direct_getter<Get>::value
+				  || is_isolate_getter<Get>::value,
+				  "property get function must be either `T ()` or \
+		`void (v8::Local<v8::String> name, v8::PropertyCallbackInfo<v8::Value> const& info)` or \
+		`T (v8::Isolate*)`");
+
+	static void get_impl(class_type& obj, Attribute attr, Get get, v8::Local<v8::String>,
+						 v8::PropertyCallbackInfo<v8::Value> const& info, getter_tag)
+	{
+		info.GetReturnValue().Set(to_v8(info.GetIsolate(), ((obj.*attr).*get)()));
+	}
+
+	static void get_impl(class_type& obj, Attribute attr, Get get,
+						 v8::Local<v8::String> name, v8::PropertyCallbackInfo<v8::Value> const& info,
+						 direct_getter_tag)
+	{
+		((obj.*attr).*get)(name, info);
+	}
+
+	static void get_impl(class_type& obj, Attribute attr, Get get, v8::Local<v8::String>,
+						 v8::PropertyCallbackInfo<v8::Value> const& info, isolate_getter_tag)
+	{
+		v8::Isolate* isolate = info.GetIsolate();
+
+		info.GetReturnValue().Set(to_v8(isolate, ((obj.*attr).*get)(isolate)));
+	}
+
+	template<typename Traits>
+	static void get(v8::Local<v8::String> name,
+					v8::PropertyCallbackInfo<v8::Value> const& info)
+	try
+	{
+	    static_assert(std::is_member_pointer<Attribute>::value,"XXX");
+		auto obj = v8pp::class_<class_type, Traits>::unwrap_object(info.GetIsolate(), info.This());
+		assert(obj);
+
+		property_type const& prop = detail::get_external_data<property_type>(info.Data());
+		assert(prop.getter);
+        assert(prop.attr);
+
+		if (obj && prop.getter && prop.attr)
+		{
+			get_impl(*obj, prop.attr, prop.getter, name, info, select_getter_tag<Get>());
+		}
+	}
+	catch (std::exception const& ex)
+	{
+		info.GetReturnValue().Set(throw_ex(info.GetIsolate(), ex.what()));
+	}
+
+	static void set_impl(class_type& obj, Attribute attr, Set set, v8::Local<v8::String>,
+						 v8::Local<v8::Value> value, v8::PropertyCallbackInfo<void> const& info,
+						 setter_tag)
+	{
+		using value_type = typename call_from_v8_traits<Set>::template arg_type<0>;
+
+		((obj.*attr).*set)(v8pp::from_v8<value_type>(info.GetIsolate(), value));
+	}
+
+	static void set_impl(class_type& obj, Attribute attr, Set set, v8::Local<v8::String> name,
+						 v8::Local<v8::Value> value, v8::PropertyCallbackInfo<void> const& info,
+						 direct_setter_tag)
+	{
+		((obj.*attr).*set)(name, value, info);
+	}
+
+	static void set_impl(class_type& obj, Attribute attr, Set set, v8::Local<v8::String>,
+						 v8::Local<v8::Value> value, v8::PropertyCallbackInfo<void> const& info,
+						 isolate_setter_tag)
+	{
+		using value_type = typename call_from_v8_traits<Set>::template arg_type<1>;
+
+		v8::Isolate* isolate = info.GetIsolate();
+
+		((obj.*attr).*set)(isolate, v8pp::from_v8<value_type>(isolate, value));
+	}
+
+	template<typename Traits>
+	static void set(v8::Local<v8::String> name, v8::Local<v8::Value> value,
+					v8::PropertyCallbackInfo<void> const& info)
+	try
+	{
+		auto obj = v8pp::class_<class_type, Traits>::unwrap_object(info.GetIsolate(), info.This());
+		assert(obj);
+
+		property_type const& prop = detail::get_external_data<property_type>(info.Data());
+		assert(prop.setter);
+
+		if (obj && prop.setter)
+		{
+			set_impl(*obj, prop.attr, prop.setter, name, value, info, select_setter_tag<Set>());
+		}
+	}
+	catch (std::exception const& ex)
+	{
+		info.GetReturnValue().Set(throw_ex(info.GetIsolate(), ex.what()));
+	}
+
+};
 } // namespace detail
 
 /// Property with get and set functions
@@ -386,6 +506,53 @@ struct property_<Get, Get>
 	}
 };
 
+/// Property with get and set functions
+template<typename Attribute, typename Get, typename Set>
+struct member_property_
+			: detail::rw_member_property<Attribute, Get, Set>
+	{
+        static_assert(std::is_member_pointer<Attribute>::value, "member property must be `&T::member`");
+
+		static_assert(detail::is_getter<Get>::value
+					  || detail::is_direct_getter<Get>::value
+					  || detail::is_isolate_getter<Get>::value,
+					  "property get function must be either `T ()` or "
+					  "`void (v8::Local<v8::String> name, v8::PropertyCallbackInfo<v8::Value> const& info)` or "
+					  "`T (v8::Isolate*)`");
+
+		static_assert(detail::is_loose_setter<Set>::value, "wtf?");
+
+		static_assert(detail::is_setter<Set>::value
+					  || detail::is_direct_setter<Set>::value
+					  || detail::is_isolate_setter<Set>::value
+					  || detail::is_loose_setter<Set>::value,
+					  "property set function must be either `void (T)` or \
+		`void (v8::Local<v8::String> name, v8::Local<v8::Value> value, v8::PropertyCallbackInfo<void> const& info)` or \
+		`void (v8::Isolate*, T)` or \
+        `T& (T::()(const T2&)`"
+       );
+
+		Attribute attr;
+		Get getter;
+		Set setter;
+
+		enum { is_readonly = false };
+
+		member_property_(Attribute attr, Get getter, Set setter)
+				: attr(attr)
+				, getter(getter)
+				, setter(setter)
+		{
+		}
+
+		template<typename OtherAttribute, typename OtherGet, typename OtherSet>
+		member_property_(member_property_<OtherAttribute, OtherGet, OtherSet> const& other)
+				: attr(other.attr)
+				, getter(other.getter)
+				, setter(other.setter)
+		{
+		}
+	};
 /// Create read/write property from get and set member functions
 template<typename Get, typename Set>
 property_<Get, Set> property(Get get, Set set)
@@ -398,6 +565,11 @@ template<typename Get>
 property_<Get, Get> property(Get get)
 {
 	return property_<Get, Get>(get);
+}
+
+template<typename Attribute, typename Get, typename Set>
+member_property_<Attribute, Get, Set> property(Attribute attr, Get get, Set set) {
+	return member_property_<Attribute, Get, Set>(attr, get, set);
 }
 
 } // namespace v8pp

--- a/v8pp/throw_ex.ipp
+++ b/v8pp/throw_ex.ipp
@@ -4,13 +4,13 @@ namespace v8pp {
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str)
 {
-	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str));
+	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str).FromMaybe(v8::Local<v8::String>()));
 }
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str,
 	v8::Local<v8::Value> (*exception_ctor)(v8::Local<v8::String>))
 {
-	return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str)));
+	return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).FromMaybe(v8::Local<v8::String>())));
 }
 
 } // namespace v8pp

--- a/v8pp/throw_ex.ipp
+++ b/v8pp/throw_ex.ipp
@@ -4,13 +4,13 @@ namespace v8pp {
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str)
 {
-	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str).FromMaybe(v8::Local<v8::String>()));
+	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str).ToLocalChecked());
 }
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str,
 	v8::Local<v8::Value> (*exception_ctor)(v8::Local<v8::String>))
 {
-	return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).FromMaybe(v8::Local<v8::String>())));
+	return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).ToLocalChecked()));
 }
 
 } // namespace v8pp

--- a/v8pp/throw_ex.ipp
+++ b/v8pp/throw_ex.ipp
@@ -4,13 +4,21 @@ namespace v8pp {
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str)
 {
+#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 1)
 	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str).ToLocalChecked());
+#else
+    return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str));
+#endif
 }
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str,
 	v8::Local<v8::Value> (*exception_ctor)(v8::Local<v8::String>))
 {
-	return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).ToLocalChecked()));
+#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 1)
+        return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).ToLocalChecked()));
+#else
+        return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str)));
+#endif
 }
 
 } // namespace v8pp

--- a/v8pp/throw_ex.ipp
+++ b/v8pp/throw_ex.ipp
@@ -4,7 +4,7 @@ namespace v8pp {
 
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str)
 {
-#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 1)
+#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 6)
 	return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str).ToLocalChecked());
 #else
     return isolate->ThrowException(v8::String::NewFromUtf8(isolate, str));
@@ -14,7 +14,7 @@ V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str)
 V8PP_IMPL v8::Local<v8::Value> throw_ex(v8::Isolate* isolate, char const* str,
 	v8::Local<v8::Value> (*exception_ctor)(v8::Local<v8::String>))
 {
-#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 1)
+#if (V8_MAJOR_VERSION > 7) || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION >= 6)
         return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str).ToLocalChecked()));
 #else
         return isolate->ThrowException(exception_ctor(v8::String::NewFromUtf8(isolate, str)));


### PR DESCRIPTION
The PR contains the following changes:
1. Support for const members pointers (as an overload of set_const). This requires special handling as the setter cannot compile and the readonly runtime check wasn't sufficient
2. Support for members with special accessors (a class containing a property which has itself special setter/getter). The more natural behavior is that X.y = z will invoke X.y.setZ(). Previous syntax forced using (n JS X.y.z or X.y.setZ() )
3. Support for "chainable setters" these return T& instead of void and support a "fluent" syntax X.setY().setZ(). In JS they are treated as properties and thus are not chainable, but it doesn't require library changes to get wrapped. 

P.S.
Thanks for the awesome library