### PR TITLE
Support context scopes and explicit enters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ AR = ar
 ARFLAGS = rcs
 
 INCLUDES = -I. -I./v8pp -isystem./v8/include -isystem./v8 -isystem/usr -isystem/usr/lib -isystem/opt/libv8-${V8_VERSION}/include
-LIBS = -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L. -Wl,-whole-archive -lv8pp -Wl,-no-whole-archive -ldl -lpthread
+LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L.  -lv8pp -ldl -lpthread
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/test/test_context.cpp
+++ b/test/test_context.cpp
@@ -43,4 +43,47 @@ void test_context()
 
 		check_eq("run_script", r, 42);
 	}
+
+	{
+		v8::Isolate* isolate = nullptr;
+		v8::ArrayBuffer::Allocator* allocator = nullptr;
+		bool add_default_global_methods = false;
+        bool enter_context = false;
+		v8pp::context context(isolate, allocator, add_default_global_methods, enter_context);
+
+		v8::HandleScope scope(context.isolate());
+        context.enter();
+		v8::Local<v8::Object> global = context.isolate()->GetCurrentContext()->Global();
+		v8::Local<v8::Value> value;
+		check("no global require", !v8pp::get_option(context.isolate(), global, "require", value));
+		check("no global run", !v8pp::get_option(context.isolate(), global, "run", value));
+
+		int const r = context.run_script("'4' + 2")->Int32Value(context.isolate()->GetCurrentContext()).FromJust();
+        context.exit();
+
+		check_eq("run_script with explicit context", r, 42);
+	}
+	
+	/*
+	// The following can't be run in this process because once the v8::Locker
+	// exits, it needs to be reaquired for all other tests to succeed
+	{
+		v8::Isolate* isolate = nullptr;
+		v8::ArrayBuffer::Allocator* allocator = nullptr;
+		bool add_default_global_methods = false;
+        bool enter_context = false;
+		v8pp::context context(isolate, allocator, add_default_global_methods, enter_context);
+
+		v8::HandleScope scope(context.isolate());
+		v8pp::context::context_scope context_scope(context);
+		v8::Local<v8::Object> global = context.isolate()->GetCurrentContext()->Global();
+		v8::Local<v8::Value> value;
+		check("no global require", !v8pp::get_option(context.isolate(), global, "require", value));
+		check("no global run", !v8pp::get_option(context.isolate(), global, "run", value));
+
+		int const r = context.run_script("'4' + 2")->Int32Value(context.isolate()->GetCurrentContext()).FromJust();
+
+		check_eq("run_script with context guard", r, 42);
+	}
+	*/
 }

--- a/test/test_context.cpp
+++ b/test/test_context.cpp
@@ -74,7 +74,6 @@ void test_context()
         bool enter_context = false;
 		v8pp::context context(isolate, allocator, add_default_global_methods, enter_context);
 
-		v8::HandleScope scope(context.isolate());
 		v8pp::context::context_scope context_scope(context);
 		v8::Local<v8::Object> global = context.isolate()->GetCurrentContext()->Global();
 		v8::Local<v8::Value> value;

--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -308,6 +308,7 @@ context::context_scope::context_scope(context &context) :
   if (owns_locks_){
 	::new(&locks_.locker)v8::Locker(context_.isolate());
 	::new(&locks_.scope)v8::Isolate::Scope(context_.isolate());
+	::new(&locks_.handle)v8::HandleScope(context_.isolate());
   }
   context_.enter();
 }
@@ -315,6 +316,7 @@ context::context_scope::context_scope(context &context) :
 context::context_scope::~context_scope() {
   context_.exit();
   if (owns_locks_){
+	locks_.handle.~HandleScope();
 	locks_.scope.~Scope();
 	locks_.locker.~Locker();
   }

--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -165,7 +165,7 @@ struct array_buffer_allocator : v8::ArrayBuffer::Allocator
 static array_buffer_allocator array_buffer_allocator_;
 
 context::context(v8::Isolate* isolate, v8::ArrayBuffer::Allocator* allocator,
-	bool add_default_global_methods)
+	bool add_default_global_methods, bool enter_context)
 {
 	own_isolate_ = (isolate == nullptr);
 	if (own_isolate_)
@@ -193,7 +193,10 @@ context::context(v8::Isolate* isolate, v8::ArrayBuffer::Allocator* allocator,
 	}
 
 	v8::Local<v8::Context> impl = v8::Context::New(isolate_, nullptr, global);
-	impl->Enter();
+    enter_context_ = enter_context;
+    if (enter_context_) {
+      impl->Enter();
+    }
 	impl_.Reset(isolate_, impl);
 }
 
@@ -217,8 +220,10 @@ context::~context()
 	}
 	modules_.clear();
 
-	v8::Local<v8::Context> impl = to_local(isolate_, impl_);
-	impl->Exit();
+    if (enter_context_) {
+      v8::Local<v8::Context> impl = to_local(isolate_, impl_);
+      impl->Exit();
+    }
 
 	impl_.Reset();
 	if (own_isolate_)
@@ -273,4 +278,45 @@ v8::Local<v8::Value> context::run_script(std::string const& source,
 	return scope.Escape(result);
 }
 
+/// Enter the context 
+void context::enter() 
+{
+	v8::HandleScope scope(isolate_);
+    v8::Local<v8::Context> impl = to_local(isolate_, impl_);
+    impl->Enter();
+
+}
+
+    /// Exit the context
+void context::exit() 
+{
+
+	v8::HandleScope scope(isolate_);
+    v8::Local<v8::Context> impl = to_local(isolate_, impl_);
+    impl->Exit();
+}
+
+  /// The context_scope class is an RAII guard to enter and exit the contex's scope. 
+  /// In Multithreaded scenarios the users of the library must enter the context before running.
+  /// Note, 
+  /// 1. If the context owns the Isolate then this guard will also Enter the isolate.
+    /// 2. If the context owns the Isolate then this will also aquire the Locker for this thread  
+context::context_scope::context_scope(context &context) :
+  context_(context)
+{
+  owns_locks_ = context_.own_isolate_;
+  if (owns_locks_){
+	::new(&locks_.locker)v8::Locker(context_.isolate());
+	::new(&locks_.scope)v8::Isolate::Scope(context_.isolate());
+  }
+  context_.enter();
+}
+
+context::context_scope::~context_scope() {
+  context_.exit();
+  if (owns_locks_){
+	locks_.scope.~Scope();
+	locks_.locker.~Locker();
+  }
+}
 } // namespace v8pp

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -27,12 +27,14 @@ class class_;
 class context
 {
 public:
+
 	/// Create context with optional existing v8::Isolate
 	/// and v8::ArrayBuffer::Allocator,
 	//  and add default global methods (`require()`, `run()`)
 	explicit context(v8::Isolate* isolate = nullptr,
 		v8::ArrayBuffer::Allocator* allocator = nullptr,
-		bool add_default_global_methods = true);
+		bool add_default_global_methods = true,
+        bool enter_context = true);
 	~context();
 
 	/// V8 isolate associated with this context
@@ -68,7 +70,41 @@ public:
 		return set(name, cl.js_function_template()->GetFunction(isolate_->GetCurrentContext()).ToLocalChecked());
 	}
 
+    /// Enter the context 
+    void enter();
+
+    /// Exit the context
+    void exit();
+
+    /// The context_scope class is an RAII guard to enter and exit the contex's scope. 
+    /// In Multithreaded scenarios the users of the library must enter the context before running.
+    /// Note, 
+    /// 1. If the context owns the Isolate then this guard will also Enter the isolate.
+    /// 2. If the context owns the Isolate then this will also aquire the Locker for this thread  
+    class context_scope {
+      public:
+        context_scope(context &context);
+        ~context_scope();
+        context_scope(context_scope &&other) = delete;
+        context_scope(const context_scope &other) = delete;
+        context_scope &operator=(const context_scope &other) = delete;
+
+      private:
+        context &context_;
+        struct empty_struct {};
+        struct v8locks {
+          v8::Locker locker;
+          v8::Isolate::Scope scope;
+        };
+        bool owns_locks_;
+        union {
+          empty_struct empty_;
+          v8locks locks_;
+        };
+    };
+
 private:
+    bool enter_context_;
 	bool own_isolate_;
 	v8::Isolate* isolate_;
 	v8::Global<v8::Context> impl_;

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -95,6 +95,7 @@ public:
         struct v8locks {
           v8::Locker locker;
           v8::Isolate::Scope scope;
+		  v8::HandleScope handle;
         };
         bool owns_locks_;
         union {


### PR DESCRIPTION
Using v8 in a multi-threaded environment requires explicit calls to enter and exit the context. 
This patch adds support for asking context to switch to explicit enter/exit pairs (default is still to implicitly Enter the context)

In addition, this patch introduces the context::context_scope class which is an RAII to Enter and Exit the context. When the isolate is owned by the context, in addition to enter the context, it also acquires a v8::Locker and enters the Isolate. 

This means that by acquiring a context_scope you can safely call JS from any thread.
