### PR TITLE
Auto wrap pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ AR = ar
 ARFLAGS = rcs
 
 INCLUDES = -I. -I./v8pp -isystem./v8/include -isystem./v8 -isystem/usr -isystem/usr/lib -isystem/opt/libv8-${V8_VERSION}/include
-LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L.  -ldl -lpthread
+LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L. -lv8pp -ldl -lpthread
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
@@ -13,7 +13,7 @@ LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VER
 all: lib plugins v8pp_test
 
 v8pp_test: $(patsubst %.cpp, %.o, $(wildcard test/*.cpp))
-	$(CXX) $^ -o $@ $(LIBS) libv8pp.a
+	$(CXX) $^ -o $@ $(LIBS)
 
 lib: $(patsubst %.cpp, %.o, $(wildcard v8pp/*.cpp))
 	$(AR) $(ARFLAGS) libv8pp.a $^

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ AR = ar
 ARFLAGS = rcs
 
 INCLUDES = -I. -I./v8pp -isystem./v8/include -isystem./v8 -isystem/usr -isystem/usr/lib -isystem/opt/libv8-${V8_VERSION}/include
-LIBS = -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L. -Wl,-whole-archive -lv8pp -Wl,-no-whole-archive -ldl -lpthread
+LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L.  -ldl -lpthread
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
@@ -13,7 +13,7 @@ LIBS = -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERS
 all: lib plugins v8pp_test
 
 v8pp_test: $(patsubst %.cpp, %.o, $(wildcard test/*.cpp))
-	$(CXX) $^ -o $@ $(LIBS)
+	$(CXX) $^ -o $@ $(LIBS) libv8pp.a
 
 lib: $(patsubst %.cpp, %.o, $(wildcard v8pp/*.cpp))
 	$(AR) $(ARFLAGS) libv8pp.a $^

--- a/test/test_class.cpp
+++ b/test/test_class.cpp
@@ -448,3 +448,36 @@ void test_class()
 	test_auto_wrap_objects<v8pp::raw_ptr_traits>();
 	test_auto_wrap_objects<v8pp::shared_ptr_traits>();
 }
+
+class NCC  {
+  public:
+  NCC() = default;
+  NCC(const NCC &) = delete;
+  
+};
+
+class CC {
+  public:
+  CC() = default;
+  CC(const CC &) = default;
+};
+
+void test_non_copy_constructible() {
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+    v8pp::class_<NCC> NCC_class(isolate);
+    NCC ncc;
+    auto wrapped_ncc= NCC_class.reference_external(isolate, &ncc);
+    auto instance_ncc = v8pp::to_v8(isolate, &ncc);
+    check("instance_ncc should be empty for non-copy constructible pointers", instance_ncc.IsEmpty());
+
+    v8pp::class_<CC> CC_class(isolate);
+    CC cc;
+    auto wrapped_cc = CC_class.reference_external(isolate, &cc);
+    auto instance_cc = v8pp::to_v8(isolate, &ncc);
+    check("A copy is returned for copyable instance_ccs", !instance_cc.IsEmpty());
+    auto cc_copy = CC_class.unwrap_object(isolate, instance_cc.As<v8::Value>());
+    check("A copy is returned for copyable instance_ccs", &cc != cc_copy);
+
+}

--- a/v8pp/ptr_traits.hpp
+++ b/v8pp/ptr_traits.hpp
@@ -52,10 +52,21 @@ struct raw_ptr_traits
 		return new T(src);
 	}
 
-	template<typename T>
-	static object_pointer_type<T> ptr_clone(object_const_pointer_type<T> src)
+
+    template<class T> 
+    static 
+    typename std::enable_if<std::is_copy_constructible<T>::value, object_pointer_type<T>>::type
+	ptr_clone(object_const_pointer_type<T> src)
 	{
 		return new T(*src);
+	}
+
+    template<class T> 
+    static 
+    typename std::enable_if<!std::is_copy_constructible<T>::value, object_pointer_type<T>>::type
+	ptr_clone(object_const_pointer_type<T> src)
+	{
+		return nullptr;
 	}
 
 	template<typename T>

--- a/v8pp/ptr_traits.hpp
+++ b/v8pp/ptr_traits.hpp
@@ -53,6 +53,12 @@ struct raw_ptr_traits
 	}
 
 	template<typename T>
+	static object_pointer_type<T> ptr_clone(object_const_pointer_type<T> src)
+	{
+		return new T(*src);
+	}
+
+	template<typename T>
 	static void destroy(object_pointer_type<T> const& ptr)
 	{
 		delete ptr;
@@ -101,6 +107,12 @@ struct shared_ptr_traits
 	static object_pointer_type<T> clone(T const& src)
 	{
 		return std::make_shared<T>(src);
+	}
+
+	template<typename T>
+	static object_pointer_type<T> ptr_clone(object_const_pointer_type<T> src)
+	{
+		return std::const_pointer_cast<T>(src);
 	}
 
 	template<typename T>


### PR DESCRIPTION
Support auto_wrap when a pointer type is returned from function.
In existing code, when a pointer type is returned from wrapped method, it will ignore the auto_wrap flag and only wrap if object is *already* wrapped using  `class_<T>::reference_external` or `class_<T>::import_external`.
With this patch, when a pointer type is returned (technically when passed to find_object) if auto-wrap is supported either of the following two happens.
1. If the return type is std::shared_ptr<T> and we've defined `auto_wrap` for `class_<T, shared_ptr_traits>`, this object is wrapped and returned.
2. If the return type is T* and we've defined `auto_wrap` for `class_<T, raw_ptr_traits>` and T is `std::is_copy_constructible` than T is copy-constructed the *copy* is wrapped.
Otherwise, the existing behavior (i.e. returning an empty handle) is kept

This patch includes the changes in ptr_traits.hpp and additional tests to ensure the above works correctly.