### PR TITLE
Extend class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ AR = ar
 ARFLAGS = rcs
 
 INCLUDES = -I. -I./v8pp -isystem./v8/include -isystem./v8 -isystem/usr -isystem/usr/lib -isystem/opt/libv8-${V8_VERSION}/include
-LIBS = -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L. -Wl,-whole-archive -lv8pp -Wl,-no-whole-archive -ldl -lpthread
+LIBS += -L./v8/lib -L/opt/libv8-${V8_VERSION}/lib -Wl,-rpath,/opt/libv8-${V8_VERSION}/lib -lv8 -lv8_libplatform -lv8_libbase -licui18n -licuuc -L. -lv8pp -ldl -lpthread
 
 .cpp.o:
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/test/test_class.cpp
+++ b/test/test_class.cpp
@@ -174,6 +174,8 @@ void test_class_()
 			})
 		;
 
+	auto Y_class_find  = v8pp::class_<Y, Traits>::extend_class(isolate);
+
 	check_ex<std::runtime_error>("already wrapped class X", [isolate]()
 	{
 		v8pp::class_<X, Traits> X_class(isolate);

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -191,6 +191,8 @@ public:
 	{
 	}
 
+	static class_ extend_class(v8::Isolate* isolate) { return class_(isolate, detail::type_id<T>());}
+
 	/// Set class constructor signature
 	template<typename ...Args, typename Create = factory_create<Args...>>
 	class_& ctor(ctor_function create = &Create::call)
@@ -439,6 +441,9 @@ public:
 	}
 
 private:
+	explicit class_(v8::Isolate *isolate, detail::type_info const &ty) :
+		class_info_(detail::classes::find<Traits>(isolate, ty)) { }
+
 	template<typename Attribute>
 	static void member_get(v8::Local<v8::String>,
 		v8::PropertyCallbackInfo<v8::Value> const& info)


### PR DESCRIPTION
Ability to get an `class_<T>` back from "classes" registry so that members can be added after declaration is done. Call is explicit using `class_<T>::extend_class`