### PR TITLE
Destroy external objects in context

### DIFF
--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -42,8 +42,17 @@ public:
 	operator T() const { return value; }
 };
 
+class external_data_base
+{
+public:
+    static constexpr uint16_t class_id = 1;
+    virtual ~external_data_base(){
+
+    }
+};
+
 template<typename T>
-class external_data
+class external_data final : public external_data_base
 {
 public:
 	static v8::Local<v8::External> set(v8::Isolate* isolate, T&& data)
@@ -61,6 +70,7 @@ public:
 
 		v8::Local<v8::External> ext = v8::External::New(isolate, value);
 		value->pext_.Reset(isolate, ext);
+		value->pext_.SetWrapperClassId(external_data_base::class_id);
 		value->pext_.SetWeak(value,
 			[](v8::WeakCallbackInfo<external_data> const& data)
 		{


### PR DESCRIPTION
The current v8 library does not provide any guarantees about when garbage collection of external objects will be performed, even after the underlying context is destroyed. This can cause issues with tests (valgrind, asan, etc.) and during runtime (especially for large externally-managed objects).

This PR seeks to the implement basic cleanup method [0] during v8pp::context destruction by visiting all objects created with `external_data<T>`, which are derived from a new base class `external_data_base`. This manual destruction incurs a small runtime cost during v8pp::context (including one call to `destroyObjects` and a vtable lookup for each object) but is likely preferable to calling the GC cleanup directly.

The tables below show the before and after results of a leak check of v8pp_test using valgrind:

Before:
```
== LEAK SUMMARY:
==    definitely lost: 2,008 bytes in 59 blocks
==    indirectly lost: 0 bytes in 0 blocks
==      possibly lost: 0 bytes in 0 blocks
==    still reachable: 153 bytes in 4 blocks
==         suppressed: 0 bytes in 0 blocks
```
After:
```
== LEAK SUMMARY:
==    definitely lost: 8 bytes in 2 blocks
==    indirectly lost: 0 bytes in 0 blocks
==      possibly lost: 0 bytes in 0 blocks
==    still reachable: 153 bytes in 4 blocks
==         suppressed: 0 bytes in 0 blocks
```

The 8 bytes in the 'after' leak summary don't seem to be from `external_data` but rather `v8pp::factory<>` in test_class.cpp.

[0] https://itnext.io/v8-wrapped-objects-lifecycle-42272de712e0