### PR TITLE
Generic converters for sequence containers, mappings, strings

### DIFF
--- a/test/test.hpp
+++ b/test/test.hpp
@@ -181,6 +181,18 @@ void check_eq(v8pp::string_view msg, T actual, U expected)
 	}
 }
 
+template<typename T>
+void check_eq(v8pp::string_view msg, T actual, v8pp::u16string_view expected)
+{
+	check(msg, actual == expected);
+}
+
+template<typename T>
+void check_eq(v8pp::string_view msg, T actual, v8pp::wstring_view expected)
+{
+	check(msg, actual == expected);
+}
+
 template<typename Ex, typename F>
 void check_ex(v8pp::string_view msg, F&& f)
 {

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -13,12 +13,20 @@
 #include <vector>
 #include <map>
 
+template<typename T, typename U>
+void test_conv(v8::Isolate* isolate, T value, U expected)
+{
+	auto const obtained = v8pp::from_v8<U>(isolate, v8pp::to_v8(isolate, value));
+	check_eq(v8pp::detail::type_id<T>().name(), obtained, expected);
+
+	auto const obtained2 = v8pp::from_v8<T>(isolate, v8pp::to_v8(isolate, expected));
+	check_eq(v8pp::detail::type_id<U>().name(), obtained2, value);
+}
+
 template<typename T>
 void test_conv(v8::Isolate* isolate, T value)
 {
-	v8::Local<v8::Value> v8_value = v8pp::to_v8(isolate, value);
-	auto const value2 = v8pp::from_v8<T>(isolate, v8_value);
-	check(v8pp::detail::type_id<T>().name(), value2 == value);
+	test_conv(isolate, value, value);
 }
 
 template<typename Char, size_t N>
@@ -156,6 +164,8 @@ void test_convert()
 
 	const std::vector<int> vector{ 1, 2, 3 };
 	test_conv(isolate, vector);
+	test_conv(isolate, std::deque<unsigned>{ 1, 2, 3 }, vector);
+	test_conv(isolate, std::list<int>{ 1, 2, 3 }, vector);
 
 	const std::array<int, 3> array{ 1, 2, 3 };
 	test_conv(isolate, array);

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -154,30 +154,28 @@ void test_convert()
 	test_string_conv(isolate, L"qaz");
 #endif
 
-	using int_vector = std::vector<int>;
-
-	int_vector vector = { 1, 2, 3 };
+	const std::vector<int> vector{ 1, 2, 3 };
 	test_conv(isolate, vector);
 
-	std::map<char, int> map = { { 'a', 1 }, { 'b', 2 }, { 'c', 3 } };
-	test_conv(isolate, map);
-
-	std::array<int, 3> array = { { 1, 2, 3 } };
+	const std::array<int, 3> array{ 1, 2, 3 };
 	test_conv(isolate, array);
-
 	check_ex<std::runtime_error>("wrong array length", [isolate, &array]()
 	{
 		v8::Local<v8::Array> arr = v8pp::to_v8(isolate, array);
 		v8pp::from_v8<std::array<int, 2>>(isolate, arr);
 	});
 
+	test_conv(isolate, std::map<char, int>{ { 'a', 1 }, { 'b', 2 }, { 'c', 3 } });
+	test_conv(isolate, std::multimap<int, int>{ { 1, -1 }, { 2, -2 }});
+	test_conv(isolate, std::unordered_map<char, std::string>{ { 'x', "1" }, { 'y', "2" }});
+	test_conv(isolate, std::unordered_multimap<std::string, int>{ { "a", 1 }, { "b", 2 }});
+
 	check_eq("initializer list to array",
-		v8pp::from_v8<int_vector>(isolate, v8pp::to_v8(isolate,
-		{ 1, 2, 3 })), vector);
+		v8pp::from_v8<std::vector<int>>(isolate, v8pp::to_v8(isolate, { 1, 2, 3 })), vector);
 
 	std::list<int> list = { 1, 2, 3 };
-	check_eq("pair of iterators to array", v8pp::from_v8<int_vector>(isolate,
-		v8pp::to_v8(isolate, list.begin(), list.end())), vector);
+	check_eq("pair of iterators to array",
+		v8pp::from_v8<std::vector<int>>(isolate, v8pp::to_v8(isolate, list.begin(), list.end())), vector);
 
 	person p;
 	p.name = "Al"; p.age = 33;

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -249,6 +249,9 @@ void test_type_traits()
 	static_assert(v8pp::detail::is_mapping<std::unordered_multimap<char, std::string>>::value, "std::unordered_multimap");
 	static_assert(!v8pp::detail::is_sequence<std::unordered_multimap<int, char>>::value, "std::unordered_multimap");
 	static_assert(!v8pp::detail::is_array<std::unordered_multimap<int, char>>::value, "std::unordered_multimap");
+
+	static_assert(!v8pp::detail::is_shared_ptr<int>::value, "int");
+	static_assert(v8pp::detail::is_shared_ptr<std::shared_ptr<int>>::value, "int");
 }
 
 struct some_struct {};

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -180,12 +180,13 @@ void test_is_callable()
 	static_assert(!is_callable<Y>::value, "Y is not callable");
 }
 
-struct some_struct {};
-namespace test { class some_class {}; }
-
-void test_utility()
+void test_type_traits()
 {
 	static_assert(v8pp::detail::is_string<std::string>::value, "std::string");
+	static_assert(!v8pp::detail::is_sequence<std::string>::value, "std::string");
+	static_assert(!v8pp::detail::is_mapping<std::string>::value, "std::string");
+	static_assert(!v8pp::detail::is_array<std::string>::value, "std::string");
+
 	static_assert(v8pp::detail::is_string<v8pp::string_view>::value, "std::string_view");
 	static_assert(v8pp::detail::is_string<std::u16string>::value, "std::u16string");
 	static_assert(v8pp::detail::is_string<v8pp::u16string_view>::value, "std::u16string_view");
@@ -198,11 +199,64 @@ void test_utility()
 	static_assert(v8pp::detail::is_string<char32_t const*>::value, "char32_t const*");
 	static_assert(v8pp::detail::is_string<wchar_t const*>::value, "wchar_t const*");
 
-	static_assert(v8pp::detail::is_mapping<std::map<int, float>>::value, "std::map");
-	static_assert(v8pp::detail::is_mapping<std::multimap<bool, std::string, std::greater<>>>::value, "std::multimap");
-	static_assert(v8pp::detail::is_mapping<std::unordered_map<std::string, std::string>>::value, "std::unordered_map");
-	static_assert(v8pp::detail::is_mapping<std::unordered_multimap<char, std::string>>::value, "std::unordered_multimap");
+	static_assert(!v8pp::detail::is_string<std::array<int, 1>>::value, "std::array");
+	static_assert(!v8pp::detail::is_mapping<std::array<int, 1>>::value, "std::array");
+	static_assert(!v8pp::detail::is_sequence<std::array<int, 1>>::value, "std::array");
+	static_assert(!v8pp::detail::is_sequence<std::array<int, 1>>::value, "std::array");
+	static_assert(v8pp::detail::is_array<std::array<int, 1>>::value, "std::array");
+	static_assert(!v8pp::detail::has_reserve<std::array<int, 1>>::value, "std::array");
 
+	static_assert(!v8pp::detail::is_string<std::vector<char>>::value, "std::vector");
+	static_assert(!v8pp::detail::is_mapping<std::vector<char>>::value, "std::vector");
+	static_assert(v8pp::detail::is_sequence<std::vector<char>>::value, "std::vector");
+	static_assert(!v8pp::detail::is_array<std::vector<char>>::value, "std::vector");
+	static_assert(v8pp::detail::has_reserve<std::vector<char>>::value, "std::vector");
+
+	static_assert(!v8pp::detail::is_string<std::deque<int>>::value, "std::deque");
+	static_assert(!v8pp::detail::is_mapping<std::deque<int>>::value, "std::deque");
+	static_assert(v8pp::detail::is_sequence<std::deque<int>>::value, "std::deque");
+	static_assert(!v8pp::detail::is_array<std::deque<int>>::value, "std::deque");
+	static_assert(!v8pp::detail::has_reserve<std::deque<int>>::value, "std::deque");
+
+	static_assert(!v8pp::detail::is_string<std::list<bool>>::value, "std::list");
+	static_assert(!v8pp::detail::is_mapping<std::list<bool>>::value, "std::list");
+	static_assert(v8pp::detail::is_sequence<std::list<bool>>::value, "std::list");
+	static_assert(!v8pp::detail::is_array<std::list<bool>>::value, "std::list");
+	static_assert(!v8pp::detail::has_reserve<std::list<bool>>::value, "std::list");
+
+	static_assert(!v8pp::detail::is_string<std::tuple<int, char>>::value, "std::tuple");
+	static_assert(!v8pp::detail::is_mapping<std::tuple<int, char>>::value, "std::tuple");
+	static_assert(!v8pp::detail::is_sequence<std::tuple<int, char>>::value, "std::tuple");
+	static_assert(!v8pp::detail::is_array<std::tuple<int, char>>::value, "std::tuple");
+	static_assert(v8pp::detail::is_tuple<std::tuple<int, char>>::value, "std::tuple");
+
+	static_assert(!v8pp::detail::is_string<std::map<int, float>>::value, "std::map");
+	static_assert(v8pp::detail::is_mapping<std::map<int, float>>::value, "std::map");
+	static_assert(!v8pp::detail::is_sequence<std::map<int, char>>::value, "std::map");
+	static_assert(!v8pp::detail::is_array<std::map<int, char>>::value, "std::map");
+
+	static_assert(!v8pp::detail::is_string<std::multimap<int, char>>::value, "std::multimap");
+	static_assert(v8pp::detail::is_mapping<std::multimap<bool, std::string, std::greater<>>>::value, "std::multimap");
+	static_assert(!v8pp::detail::is_sequence<std::multimap<int, char>>::value, "std::multimap");
+	static_assert(!v8pp::detail::is_array<std::multimap<int, char>>::value, "std::multimap");
+
+	static_assert(!v8pp::detail::is_string<std::unordered_map<int, char>>::value, "std::unordered_map");
+	static_assert(v8pp::detail::is_mapping<std::unordered_map<std::string, std::string>>::value, "std::unordered_map");
+	static_assert(!v8pp::detail::is_sequence<std::unordered_map<int, char>>::value, "std::unordered_map");
+	static_assert(!v8pp::detail::is_array<std::unordered_map<int, char>>::value, "std::unordered_map");
+
+	static_assert(!v8pp::detail::is_array<std::unordered_multimap<int, char>>::value, "std::unordered_multimap");
+	static_assert(v8pp::detail::is_mapping<std::unordered_multimap<char, std::string>>::value, "std::unordered_multimap");
+	static_assert(!v8pp::detail::is_sequence<std::unordered_multimap<int, char>>::value, "std::unordered_multimap");
+	static_assert(!v8pp::detail::is_array<std::unordered_multimap<int, char>>::value, "std::unordered_multimap");
+}
+
+struct some_struct {};
+namespace test { class some_class {}; }
+
+void test_utility()
+{
+	test_type_traits();
 	test_function_traits();
 	test_tuple_tail();
 	test_is_callable();

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -185,6 +185,19 @@ namespace test { class some_class {}; }
 
 void test_utility()
 {
+	static_assert(v8pp::detail::is_string<std::string>::value, "std::string");
+	static_assert(v8pp::detail::is_string<v8pp::string_view>::value, "std::string_view");
+	static_assert(v8pp::detail::is_string<std::u16string>::value, "std::u16string");
+	static_assert(v8pp::detail::is_string<v8pp::u16string_view>::value, "std::u16string_view");
+	static_assert(v8pp::detail::is_string<std::u32string>::value, "std::u32string");
+	static_assert(v8pp::detail::is_string<v8pp::u32string_view>::value, "std::u32string_view");
+	static_assert(v8pp::detail::is_string<std::wstring>::value, "std::wstring");
+	static_assert(v8pp::detail::is_string<v8pp::wstring_view>::value, "std::wstring_view");
+	static_assert(v8pp::detail::is_string<char const*>::value, "char const*");
+	static_assert(v8pp::detail::is_string<char16_t const*>::value, "char16_t const*");
+	static_assert(v8pp::detail::is_string<char32_t const*>::value, "char32_t const*");
+	static_assert(v8pp::detail::is_string<wchar_t const*>::value, "wchar_t const*");
+
 	static_assert(v8pp::detail::is_mapping<std::map<int, float>>::value, "std::map");
 	static_assert(v8pp::detail::is_mapping<std::multimap<bool, std::string, std::greater<>>>::value, "std::multimap");
 	static_assert(v8pp::detail::is_mapping<std::unordered_map<std::string, std::string>>::value, "std::unordered_map");

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -11,6 +11,9 @@
 #include "v8pp/utility.hpp"
 #include "test.hpp"
 
+#include <map>
+#include <unordered_map>
+
 template<typename Ret, typename F>
 void test_ret(F&&)
 {
@@ -182,6 +185,11 @@ namespace test { class some_class {}; }
 
 void test_utility()
 {
+	static_assert(v8pp::detail::is_mapping<std::map<int, float>>::value, "std::map");
+	static_assert(v8pp::detail::is_mapping<std::multimap<bool, std::string, std::greater<>>>::value, "std::multimap");
+	static_assert(v8pp::detail::is_mapping<std::unordered_map<std::string, std::string>>::value, "std::unordered_map");
+	static_assert(v8pp::detail::is_mapping<std::unordered_multimap<char, std::string>>::value, "std::unordered_multimap");
+
 	test_function_traits();
 	test_tuple_tail();
 	test_is_callable();

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -51,9 +51,12 @@ struct invalid_argument : std::invalid_argument
 };
 
 // converter specializations for string types
-template<typename Char, typename Traits>
-struct convert<basic_string_view<Char, Traits>>
+template<typename String>
+struct convert<String, typename std::enable_if<detail::is_string<String>::value>::type>
 {
+	using Char = typename String::value_type;
+	using Traits = typename String::traits_type;
+
 	static_assert(sizeof(Char) <= sizeof(uint16_t),
 		"only UTF-8 and UTF-16 strings are supported");
 
@@ -109,15 +112,15 @@ struct convert<basic_string_view<Char, Traits>>
 	}
 };
 
-template<typename Char, typename Traits, typename Alloc>
-struct convert<std::basic_string<Char, Traits, Alloc>> : convert<basic_string_view<Char, Traits>>
-{
-};
-
-template<typename Char>
-struct convert<Char const*> : convert<basic_string_view<Char>>
-{
-};
+// converter specializations for null-terminated strings
+template<>
+struct convert<char const*> : convert<basic_string_view<char>> {};
+template<>
+struct convert<char16_t const*> : convert<basic_string_view<char16_t>> {};
+#ifdef WIN32
+template<>
+struct convert<wchar_t const*> : convert<basic_string_view<wchar_t>> {};
+#endif
 
 // converter specializations for primitive types
 template<>

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -462,7 +462,8 @@ struct is_wrapped_class : std::conjunction<
 	std::negation<detail::is_mapping<T>>,
 	std::negation<detail::is_sequence<T>>,
 	std::negation<detail::is_array<T>>,
-	std::negation<detail::is_tuple<T>>
+	std::negation<detail::is_tuple<T>>,
+	std::negation<detail::is_shared_ptr<T>>
 > {};
 
 // convert specialization for wrapped user classes
@@ -471,9 +472,6 @@ struct is_wrapped_class<v8::Local<T>> : std::false_type {};
 
 template<typename T>
 struct is_wrapped_class<v8::Global<T>> : std::false_type {};
-
-template<typename T>
-struct is_wrapped_class<std::shared_ptr<T>> : std::false_type {};
 
 template<typename T>
 struct convert<T*, typename std::enable_if<is_wrapped_class<T>::value>::type>

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -319,12 +319,13 @@ private:
 	}
 };
 
-// convert Array <-> std::array
-template<typename T, size_t N>
-struct convert<std::array<T, N>>
+// convert Array <-> std::array, vector, deque, list
+template<typename Sequence>
+struct convert<Sequence, typename std::enable_if<detail::is_sequence<Sequence>::value || detail::is_array<Sequence>::value>::type>
 {
-	using from_type = std::array<T, N>;
+	using from_type = Sequence;
 	using to_type = v8::Local<v8::Array>;
+	using item_type = typename Sequence::value_type;
 
 	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
 	{
@@ -342,75 +343,37 @@ struct convert<std::array<T, N>>
 		v8::Local<v8::Context> context = isolate->GetCurrentContext();
 		v8::Local<v8::Array> array = value.As<v8::Array>();
 
-		if (array->Length() != N)
-		{
-			throw std::runtime_error("Invalid array length: expected "
-				+ std::to_string(N) + " actual "
-				+ std::to_string(array->Length()));
-		}
+		from_type result{};
 
-		from_type result;
-		for (uint32_t i = 0; i < N; ++i)
-		{
-			result[i] = convert<T>::from_v8(isolate, array->Get(context, i).ToLocalChecked());
-		}
-		return result;
-	}
+		using is_array = detail::is_array<Sequence>;
+		is_array::check_length(array->Length());
+		detail::has_reserve<Sequence>::reserve(result, array->Length());
 
-	static to_type to_v8(v8::Isolate* isolate, from_type const& value)
-	{
-		v8::EscapableHandleScope scope(isolate);
-		v8::Local<v8::Context> context = isolate->GetCurrentContext();
-		v8::Local<v8::Array> result = v8::Array::New(isolate, N);
-		for (uint32_t i = 0; i < N; ++i)
-		{
-			result->Set(context, i, convert<T>::to_v8(isolate, value[i])).FromJust();
-		}
-		return scope.Escape(result);
-	}
-};
-
-// convert Array <-> std::vector
-template<typename T, typename Alloc>
-struct convert<std::vector<T, Alloc>>
-{
-	using from_type = std::vector<T, Alloc>;
-	using to_type = v8::Local<v8::Array>;
-
-	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
-	{
-		return !value.IsEmpty() && value->IsArray();
-	}
-
-	static from_type from_v8(v8::Isolate* isolate, v8::Local<v8::Value> value)
-	{
-		if (!is_valid(isolate, value))
-		{
-			throw invalid_argument(isolate, value, "Array");
-		}
-
-		v8::HandleScope scope(isolate);
-		v8::Local<v8::Context> context = isolate->GetCurrentContext();
-		v8::Local<v8::Array> array = value.As<v8::Array>();
-
-		from_type result;
-		result.reserve(array->Length());
 		for (uint32_t i = 0, count = array->Length(); i < count; ++i)
 		{
-			result.emplace_back(convert<T>::from_v8(isolate, array->Get(context, i).ToLocalChecked()));
+			v8::Local<v8::Value> item = array->Get(context, i).ToLocalChecked();
+			is_array::set_element_at(result, i, convert<item_type>::from_v8(isolate, item));
 		}
 		return result;
 	}
 
 	static to_type to_v8(v8::Isolate* isolate, from_type const& value)
 	{
+		constexpr int max_size = std::numeric_limits<int>::max();
+		if (value.size() > max_size)
+		{
+			throw std::runtime_error("Invalid array length: actual "
+				+ std::to_string(value.size()) + " exceeds maximal "
+				+ std::to_string(max_size));
+		}
+
 		v8::EscapableHandleScope scope(isolate);
 		v8::Local<v8::Context> context = isolate->GetCurrentContext();
-		uint32_t const size = static_cast<uint32_t>(value.size());
-		v8::Local<v8::Array> result = v8::Array::New(isolate, size);
-		for (uint32_t i = 0; i < size; ++i)
+		v8::Local<v8::Array> result = v8::Array::New(isolate, static_cast<int>(value.size()));
+		uint32_t i = 0;
+		for (item_type const& item : value)
 		{
-			result->Set(context, i, convert<T>::to_v8(isolate, value[i])).FromJust();
+			result->Set(context, i++, convert<item_type>::to_v8(isolate, item)).FromJust();
 		}
 		return scope.Escape(result);
 	}
@@ -495,7 +458,11 @@ struct convert<v8::Local<T>>
 template<typename T>
 struct is_wrapped_class : std::conjunction<
 	std::is_class<T>,
-	std::negation<detail::is_mapping<T>>
+	std::negation<detail::is_string<T>>,
+	std::negation<detail::is_mapping<T>>,
+	std::negation<detail::is_sequence<T>>,
+	std::negation<detail::is_array<T>>,
+	std::negation<detail::is_tuple<T>>
 > {};
 
 // convert specialization for wrapped user classes
@@ -504,30 +471,6 @@ struct is_wrapped_class<v8::Local<T>> : std::false_type {};
 
 template<typename T>
 struct is_wrapped_class<v8::Global<T>> : std::false_type {};
-
-template<typename Char, typename Traits, typename Alloc>
-struct is_wrapped_class<std::basic_string<Char, Traits, Alloc>> : std::false_type {};
-
-template<typename Char, typename Traits>
-struct is_wrapped_class<basic_string_view<Char, Traits>> : std::false_type {};
-
-template<>
-struct is_wrapped_class<char const*> : std::false_type {};
-
-template<>
-struct is_wrapped_class<char16_t const*> : std::false_type {};
-
-template<>
-struct is_wrapped_class<wchar_t const*> : std::false_type {};
-
-template<typename... Ts>
-struct is_wrapped_class<std::tuple<Ts...>> : std::false_type{};
-
-template<typename T, size_t N>
-struct is_wrapped_class<std::array<T, N>> : std::false_type{};
-
-template<typename T, typename Alloc>
-struct is_wrapped_class<std::vector<T, Alloc>> : std::false_type {};
 
 template<typename T>
 struct is_wrapped_class<std::shared_ptr<T>> : std::false_type {};

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -10,6 +10,7 @@
 #define V8PP_UTILITY_HPP_INCLUDED
 
 #include <functional>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -156,11 +157,103 @@ template<typename T, typename U = void>
 struct is_mapping_impl : std::false_type {};
 
 template<typename T>
-struct is_mapping_impl<T, std::void_t<typename T::key_type, typename T::mapped_type>> : std::true_type {};
+struct is_mapping_impl<T, std::void_t<typename T::key_type, typename T::mapped_type,
+	decltype(std::declval<T>().begin()), decltype(std::declval<T>().end())>> : std::true_type {};
 
 template<typename T>
 struct is_mapping : is_mapping_impl<T>::type {};
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_sequence<T>
+//
+template<typename T, typename U = void>
+struct is_sequence_impl : std::false_type {};
+
+template<typename T>
+struct is_sequence_impl<T, std::void_t<typename T::value_type,
+	decltype(std::declval<T>().begin()), decltype(std::declval<T>().end()),
+	decltype(std::declval<T>().emplace_back(std::declval<typename T::value_type>()))>>
+	: std::negation<is_string<T>>
+{
+};
+
+template<typename T>
+struct is_sequence : is_sequence_impl<T> {};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// has_reserve<T>
+//
+template<typename T, typename U = void>
+struct has_reserve_impl : std::false_type
+{
+	static void reserve(T& container, size_t capacity) {} // no-op
+};
+
+template<typename T>
+struct has_reserve_impl<T, std::void_t<decltype(std::declval<T>().reserve(0))>> : std::true_type
+{
+	static void reserve(T& container, size_t capacity)
+	{
+		container.reserve(capacity);
+	}
+};
+
+template<typename T>
+struct has_reserve : has_reserve_impl<T>::type
+{
+	static void reserve(T& container, size_t capacity)
+	{
+		has_reserve_impl<T>::reserve(container, capacity);
+	}
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_array<T>
+//
+template<typename T>
+struct is_array : std::false_type
+{
+	static void check_length(size_t length) {} // no-op for non-arrays
+
+	template<typename U>
+	static void set_element_at(T& container, size_t index, U&& item)
+	{
+		container.emplace_back(std::forward<U>(item));
+	}
+};
+
+template<typename T, std::size_t N>
+struct is_array<std::array<T, N>> : std::true_type
+{
+	static void check_length(size_t length)
+	{
+		if (length != N)
+		{
+			throw std::runtime_error("Invalid array length: expected "
+				+ std::to_string(N) + " actual "
+				+ std::to_string(length));
+		}
+	}
+
+	template<typename U>
+	static void set_element_at(std::array<T, N>& array, size_t index, U&& item)
+	{
+		array[index] = std::forward<U>(item);
+	}
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_tuple<T>
+//
+template<typename T>
+struct is_tuple : std::false_type {};
+
+template<typename... Ts>
+struct is_tuple<std::tuple<Ts...>> : std::true_type {};
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -127,6 +127,20 @@ struct tuple_tail<std::tuple<Head, Tail...>>
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// is_mapping<T>
+//
+template<typename T, typename U = void>
+struct is_mapping_impl : std::false_type {};
+
+template<typename T>
+struct is_mapping_impl<T, std::void_t<typename T::key_type, typename T::mapped_type>> : std::true_type {};
+
+template<typename T>
+struct is_mapping : is_mapping_impl<T>::type {};
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Function traits
 //
 template<typename F>

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -11,6 +11,7 @@
 
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -254,6 +255,16 @@ struct is_tuple : std::false_type {};
 
 template<typename... Ts>
 struct is_tuple<std::tuple<Ts...>> : std::true_type {};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_shared_ptr<T>
+//
+template<typename T>
+struct is_shared_ptr : std::false_type {};
+
+template<typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -33,6 +33,7 @@ class basic_string_view
 {
 public:
 	using value_type = Char;
+	using traits_type = Traits;
 	using size_type = size_t;
 	using const_iterator = Char const*;
 
@@ -110,6 +111,7 @@ private:
 
 using string_view = basic_string_view<char>;
 using u16string_view = basic_string_view<char16_t>;
+using u32string_view = basic_string_view<char32_t>;
 using wstring_view = basic_string_view<wchar_t>;
 } // namespace v8pp {
 #endif
@@ -124,6 +126,27 @@ struct tuple_tail<std::tuple<Head, Tail...>>
 {
 	using type = std::tuple<Tail...>;
 };
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_string<T>
+//
+template<typename T> struct is_string : std::false_type {};
+
+template<typename Char, typename Traits, typename Alloc>
+struct is_string<std::basic_string<Char, Traits, Alloc>> : std::true_type {};
+
+template<typename Char, typename Traits>
+struct is_string<v8pp::basic_string_view<Char, Traits>> : std::true_type {};
+
+template<>
+struct is_string<char const*> : std::true_type {};
+template<>
+struct is_string<char16_t const*> : std::true_type {};
+template<>
+struct is_string<char32_t const*> : std::true_type {};
+template<>
+struct is_string<wchar_t const*> : std::true_type {};
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -10,7 +10,6 @@
 #define V8PP_UTILITY_HPP_INCLUDED
 
 #include <functional>
-#include <iterator>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -155,58 +154,40 @@ struct is_string<wchar_t const*> : std::true_type {};
 // is_mapping<T>
 //
 template<typename T, typename U = void>
-struct is_mapping_impl : std::false_type {};
+struct is_mapping : std::false_type {};
 
 template<typename T>
-struct is_mapping_impl<T, std::void_t<typename T::key_type, typename T::mapped_type,
+struct is_mapping<T, std::void_t<typename T::key_type, typename T::mapped_type,
 	decltype(std::declval<T>().begin()), decltype(std::declval<T>().end())>> : std::true_type {};
-
-template<typename T>
-struct is_mapping : is_mapping_impl<T>::type {};
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // is_sequence<T>
 //
 template<typename T, typename U = void>
-struct is_sequence_impl : std::false_type {};
+struct is_sequence : std::false_type {};
 
 template<typename T>
-struct is_sequence_impl<T, std::void_t<typename T::value_type,
+struct is_sequence<T, std::void_t<typename T::value_type,
 	decltype(std::declval<T>().begin()), decltype(std::declval<T>().end()),
-	decltype(std::declval<T>().emplace_back(std::declval<typename T::value_type>()))>>
-	: std::negation<is_string<T>>
-{
-};
-
-template<typename T>
-struct is_sequence : is_sequence_impl<T> {};
+	decltype(std::declval<T>().emplace_back(std::declval<typename T::value_type>()))>> : std::negation<is_string<T>> {};
 
 /////////////////////////////////////////////////////////////////////////////
 //
 // has_reserve<T>
 //
 template<typename T, typename U = void>
-struct has_reserve_impl : std::false_type
+struct has_reserve : std::false_type
 {
 	static void reserve(T& container, size_t capacity) {} // no-op
 };
 
 template<typename T>
-struct has_reserve_impl<T, std::void_t<decltype(std::declval<T>().reserve(0))>> : std::true_type
+struct has_reserve<T, std::void_t<decltype(std::declval<T>().reserve(0))>> : std::true_type
 {
 	static void reserve(T& container, size_t capacity)
 	{
 		container.reserve(capacity);
-	}
-};
-
-template<typename T>
-struct has_reserve : has_reserve_impl<T>::type
-{
-	static void reserve(T& container, size_t capacity)
-	{
-		has_reserve_impl<T>::reserve(container, capacity);
 	}
 };
 


### PR DESCRIPTION
Using `detail::is_*` meta-functions in `v8pp::convert<>` implementations, to support other standard containers (i.e. `std::list`, `std::deque`, `std::map`, `std::unordered_map` etc.) between the C++ and V8 values.