### PR TITLE
Support const member value binding

### DIFF
--- a/test/test_class.cpp
+++ b/test/test_class.cpp
@@ -445,6 +445,28 @@ void test_auto_wrap_objects()
 	check_eq("return X object", run_script<int>(context, "obj = f(123); obj.x"), 123);
 }
 
+template<typename Traits>
+void test_class_with_const_member()
+{
+    struct X
+    {
+        explicit X(const int id) : id(id) {}
+        const int id;
+    };
+
+	v8pp::context context;
+	v8::Isolate* isolate = context.isolate();
+	v8::HandleScope scope(isolate);
+
+	v8pp::class_<X, Traits> X_class(isolate);
+	X_class
+	    .template ctor<int>()
+		.set("id", &X::id);
+
+	context.set("X", X_class);
+	check_eq("x.id", run_script<int>(context, "x = new X(777);x.id"), 777);
+}
+
 void test_class()
 {
 	test_class_<v8pp::raw_ptr_traits>();
@@ -458,4 +480,7 @@ void test_class()
 
 	test_auto_wrap_objects<v8pp::raw_ptr_traits>();
 	test_auto_wrap_objects<v8pp::shared_ptr_traits>();
+	
+	test_class_with_const_member<v8pp::raw_ptr_traits>();
+	test_class_with_const_member<v8pp::shared_ptr_traits>();
 }

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -437,6 +437,12 @@ template<typename F>
 using is_callable = std::integral_constant<bool,
 	is_callable_impl<F, std::is_class<F>::value>::value>;
 
+template<class T>
+struct is_const_member_pointer : std::false_type {};
+
+template<class R, class C>
+struct is_const_member_pointer<R const C::*> : std::true_type {};
+
 /// Type information for custom RTTI
 class type_info
 {


### PR DESCRIPTION
class_::set overload for class member values don't support constant member values.
See "Add test of support const member" for example.

This PR adds overload for class_::set to support const members.
