### PR TITLE
Add support for custom global object in v8pp::context

### DIFF
--- a/v8pp/context.cpp
+++ b/v8pp/context.cpp
@@ -165,7 +165,8 @@ struct array_buffer_allocator : v8::ArrayBuffer::Allocator
 static array_buffer_allocator array_buffer_allocator_;
 
 context::context(v8::Isolate* isolate, v8::ArrayBuffer::Allocator* allocator,
-	bool add_default_global_methods, bool enter_context)
+	bool add_default_global_methods, bool enter_context,
+	global_factory_function global_factory)
 {
 	own_isolate_ = (isolate == nullptr);
 	if (own_isolate_)
@@ -181,7 +182,8 @@ context::context(v8::Isolate* isolate, v8::ArrayBuffer::Allocator* allocator,
 
 	v8::HandleScope scope(isolate_);
 
-	v8::Local<v8::ObjectTemplate> global = v8::ObjectTemplate::New(isolate_);
+	v8::Local<v8::ObjectTemplate> global = global_factory ? global_factory(isolate_)
+														  : v8::ObjectTemplate::New(isolate_);
 
 	if (add_default_global_methods)
 	{

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -27,12 +27,15 @@ class class_;
 class context
 {
 public:
+	using global_factory_function = std::function<v8::Local<v8::ObjectTemplate>(v8::Isolate*)>;
+
 	struct options
 	{
 		v8::Isolate* isolate = nullptr;
 		v8::ArrayBuffer::Allocator* allocator = nullptr;
 		bool add_default_global_methods = true;
 		bool enter_context = true;
+		global_factory_function global_factory {};
 	};
 
 	/// Create context with optional existing v8::Isolate
@@ -41,10 +44,11 @@ public:
 	explicit context(v8::Isolate* isolate = nullptr,
 		v8::ArrayBuffer::Allocator* allocator = nullptr,
 		bool add_default_global_methods = true,
-		bool enter_context = true);
+		bool enter_context = true,
+		global_factory_function global_factory = {});
 
 	explicit context(options const& opts)
-		: context(opts.isolate, opts.allocator, opts.add_default_global_methods, opts.enter_context)
+		: context(opts.isolate, opts.allocator, opts.add_default_global_methods, opts.enter_context, opts.global_factory)
 	{
 	}
 

--- a/v8pp/module.hpp
+++ b/v8pp/module.hpp
@@ -40,6 +40,9 @@ public:
 	/// v8::Isolate where the module belongs
 	v8::Isolate* isolate() { return isolate_; }
 
+	/// V8 ObjectTemplate implementation
+	v8::Local<v8::ObjectTemplate> impl() { return obj_; }
+
 	/// Set a V8 value in the module with specified name
 	template<typename Data>
 	module& set(string_view name, v8::Local<Data> value)


### PR DESCRIPTION
The feature allows to set up the global object at the context creation stage.
module already allows to export functions, modules, classes etc, so we can use modules to setup global object as soon we expose their impl.