### PR TITLE
Add first ugly support for std::function overload for v8pp::convert

### DIFF
--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -283,6 +283,16 @@ struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// is_function<T>
+//
+template<typename T>
+struct is_function : std::false_type {};
+
+template<typename R, typename ...Args>
+struct is_function<std::function<R(Args...)>> : std::true_type {};
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Function traits
 //
 template<typename F>


### PR DESCRIPTION
- [ ] Need to add tests
- [ ] Fix forward declaration of wrap_function (Template parameter redefines default argument in "typename Traits = raw_ptr_traits")
- [ ] Make sure function converter is composable with other converters (std::function<void(std::vector<int>)>, std::vector<std::function<void()>> etc)
- [ ] Fix problem that caller should additionally include v8pp/call_v8.hpp or template call_v8 would be illformed

Closes #142