### PR TITLE
Fix test that fails when v8 is built with is_debug and dcheck_always_on

### DIFF
--- a/test/test_context.cpp
+++ b/test/test_context.cpp
@@ -106,17 +106,21 @@ void test_context()
 
 		// Isolate and HandleScope shall exist before init_global
 		v8::Isolate* isolate = v8pp::context::create_isolate();
-		v8::HandleScope scope(isolate);
+		{
+			v8::Isolate::Scope isolate_scope(isolate);
+			v8::HandleScope scope(isolate);
 
-		v8pp::context::options opt;
-		opt.isolate = isolate; // use existing one
-		opt.add_default_global_methods = false;
-		opt.global = init_global(isolate);
+			v8pp::context::options opt;
+			opt.isolate = isolate; // use existing one
+			opt.add_default_global_methods = false;
+			opt.global = init_global(isolate);
 
-		v8pp::context context(opt);
+			v8pp::context context(opt);
 
-		int const r = context.run_script("value + func()")->Int32Value(context.isolate()->GetCurrentContext()).FromJust();
+			int const r = context.run_script("value + func()")->Int32Value(context.isolate()->GetCurrentContext()).FromJust();
 
-		check_eq("run_script with customized global", r, 42);
+			check_eq("run_script with customized global", r, 42);
+		}
+		isolate->Dispose();
 	}
 }


### PR DESCRIPTION
There were a couple of v8 DCHECK assertions related to the isolate not being set in the test when v8::ScriptOrigin needed it, and the Isolate not being cleaned up before shutting down v8. Tested with v8 9.4.146.22.