### PR TITLE
Fix missing INTERFACE_INCLUDE_DIRECTORIES in exported config

### DIFF
--- a/v8pp/CMakeLists.txt
+++ b/v8pp/CMakeLists.txt
@@ -1,5 +1,7 @@
 # v8pp target
 
+include(GNUInstallDirs)
+
 if(DEFINED VCPKG_TARGET_TRIPLET)
 	find_package(V8 CONFIG REQUIRED)
 else()
@@ -87,7 +89,6 @@ endif()
 #source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${V8PP_HEADERS} ${V8PP_SOURCES})
 
 # Install
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 set(targets_export_name v8pp_Targets)


### PR DESCRIPTION
CMAKE_INSTALL_INCLUDEDIR was used before including GNUInstallDirs, causing the first configuration to miss INTERFACE_INCLUDE_DIRECTORIES. Configuring a second time worked, though. Tested with CMake 3.17.5.

I haven't included it here, as I think it might be a breaking change for existing users, but I'd also suggest changing the name of the configuration file from Config.cmake to v8pp-config.cmake or v8ppConfig.cmake, as currently it looks like the config filename needs to be included in the find(). e.g. find_package(v8pp REQUIRED CONFIGS Config.cmake)

For the supported filenames, see the "Config mode" section in https://cmake.org/cmake/help/latest/command/find_package.html#search-modes