### PR TITLE
use std::numeric_limits::lowest()

### DIFF
--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -232,14 +232,14 @@ void check_range(v8::Isolate* isolate)
 	}
 	else
 	{
-		min = std::numeric_limits<T>::min();
+		min = std::numeric_limits<T>::lowest();
 		max = std::numeric_limits<T>::max();
 	}
 
 	check_range(zero);
 	check_range(min);
 	check_range(max);
-	check_range.check_ex(std::nextafter(double(min), std::numeric_limits<double>::min())); // like min - 1 (out of range)
+	check_range.check_ex(std::nextafter(double(min), std::numeric_limits<double>::lowest())); // like min - 1 (out of range)
 	check_range.check_ex(std::nextafter(double(max), std::numeric_limits<double>::max())); // like max + 1 (out of range)
 }
 

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -417,7 +417,7 @@ private:
 		}
 		else
 		{
-			Number const min = std::numeric_limits<T>::min();
+			Number const min = std::numeric_limits<T>::lowest();
 			Number const max = std::numeric_limits<T>::max();
 			if (number >= min && number <= max)
 			{


### PR DESCRIPTION
prevent issues with floating point type conversations since min doesn't return the actual minimum possible number.
as an example where this caused issues:
```cpp
void variant_test(std::variant<float, bool> test)
{
	printf("variant_test: ");
	if(std::holds_alternative<float>(test))
	{
		printf("float: %f\n", std::get<float>(test));
	}
	else if (std::holds_alternative<bool>(test))
	{
		printf("bool: %d\n", std::get<bool>(test));
	}
}
```
registering this function to javascript and calling it with (0) as argument will give the error "Unable to convert argument to variant."

![image](https://user-images.githubusercontent.com/74370284/209978169-7ae6e642-d011-4027-9041-41ef8242e581.png)
