### PR TITLE
Enhance Support for std::optional and Empty std::variant

### DIFF
--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -270,7 +270,7 @@ template<typename T>
 struct convert<std::optional<T>>
 {
 	using from_type = std::optional<T>;
-	using to_type = typename convert<T>::to_type; // v8::Local<v8::Value>;
+	using to_type = typename convert<T>::to_type;
 
 	static bool is_valid(v8::Isolate* isolate, v8::Local<v8::Value> value)
 	{
@@ -281,7 +281,7 @@ struct convert<std::optional<T>>
 	{
 		if (!is_valid(isolate, value))
 		{
-			throw invalid_argument(isolate, value, "Optional");
+			return from_type{};
 		}
 
 		return convert<T>::from_v8(isolate, value);
@@ -894,6 +894,15 @@ v8::Local<v8::String> to_v8(v8::Isolate* isolate,
 	return convert<std::wstring_view>::to_v8(isolate, std::wstring_view(str, len));
 }
 #endif
+
+template<typename T>
+auto to_v8(v8::Isolate* isolate, std::optional<T> const& value) -> v8::Local<v8::Value>
+{
+	if (value.has_value())
+		return convert<T>::to_v8(isolate, value.value());
+	else
+		return v8::Undefined(isolate);
+}
 
 template<typename T>
 auto to_v8(v8::Isolate* isolate, T const& value)

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string_view>
 #include <tuple>
+#include <optional>
 #include <type_traits>
 
 namespace v8pp { namespace detail {
@@ -155,6 +156,20 @@ struct is_shared_ptr : std::false_type
 
 template<typename T>
 struct is_shared_ptr<std::shared_ptr<T>> : std::true_type
+{
+};
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// is_optional<T>
+//
+template<typename T>
+struct is_optional : std::false_type
+{
+};
+
+template<typename T>
+struct is_optional<std::optional<T>> : std::true_type
 {
 };
 


### PR DESCRIPTION
This pull request introduces mapping for std::optional return types and parameters, providing a more seamless integration with TypeScript's optional parameters. 
The new mapping reflects the following TypeScript optional parameter syntax:
```ts
var: type | undefined
type? var
```

In addition, this commit extends std::variant support to include std::monostate, which is treated as an undefined value.