### PR TITLE
Enable C++20 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus") # enable correct __cplusplus macro
+endif()
+
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(BUILD_TESTING "Build and run tests" OFF)
 option(BUILD_DOCUMENTATION "Build documentation" OFF)

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -31,13 +31,13 @@ std::ostream& operator<<(std::ostream& os, std::array<T, N> const& array)
 	return print_sequence(os, array, "[]");
 }
 
-template<typename Char, typename Traits, typename Alloc, typename = typename std::enable_if<!std::is_same<Char, char>::value>::type>
+template<v8pp::detail::WideChar Char, typename Traits, typename Alloc>
 std::ostream& operator<<(std::ostream& os, std::basic_string<Char, Traits, Alloc> const& string)
 {
 	return print_sequence(os, string, "''");
 }
 
-template<typename Char, typename Traits, typename = typename std::enable_if_t<!std::is_same_v<Char, char>>>
+template<v8pp::detail::WideChar Char, typename Traits>
 std::ostream& operator<<(std::ostream& os, std::basic_string_view<Char, Traits> const& string_view)
 {
 	return print_sequence(os, string_view, "''");
@@ -51,6 +51,16 @@ inline std::ostream& operator<<(std::ostream& os, char16_t ch)
 inline std::ostream& operator<<(std::ostream& os, char16_t const* str)
 {
 	return print_sequence(os, std::basic_string_view<char16_t>(str), "''");
+}
+
+inline std::ostream& operator<<(std::ostream& os, char32_t ch)
+{
+	return os << static_cast<int64_t>(ch);
+}
+
+inline std::ostream& operator<<(std::ostream& os, char32_t const* str)
+{
+	return print_sequence(os, std::basic_string_view<char32_t>(str), "''");
 }
 
 inline std::ostream& operator<<(std::ostream& os, wchar_t ch)
@@ -141,7 +151,7 @@ std::ostream& operator<<(std::ostream& os, std::pair<First, Second> const& pair)
 	return os << pair.first << ": " << pair.second;
 }
 
-template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
+template<typename Enum> requires std::is_enum_v<Enum>
 std::ostream& operator<<(std::ostream& os, Enum value)
 {
 	return os << static_cast<typename std::underlying_type<Enum>::type>(value);

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -154,7 +154,7 @@ std::ostream& operator<<(std::ostream& os, std::pair<First, Second> const& pair)
 template<typename Enum> requires std::is_enum_v<Enum>
 std::ostream& operator<<(std::ostream& os, Enum value)
 {
-	return os << static_cast<typename std::underlying_type<Enum>::type>(value);
+	return os << static_cast<typename std::underlying_type_t<Enum>>(value);
 }
 
 template<typename... Ts>

--- a/test/test_call_from_v8.cpp
+++ b/test/test_call_from_v8.cpp
@@ -39,47 +39,47 @@ using arg_convert = typename call_from_v8_traits<F>::template arg_converter<
 	typename call_from_v8_traits<F>::template arg_type<Index>, Traits>;
 
 // fundamental type converters
-static_assert(std::is_same<arg_convert<decltype(y), 0, raw_ptr_traits>, v8pp::convert<int>>::value, "y(int)");
-static_assert(std::is_same<arg_convert<decltype(y), 0, shared_ptr_traits>, v8pp::convert<int>>::value, "y(int)");
+static_assert(std::same_as<arg_convert<decltype(y), 0, raw_ptr_traits>, v8pp::convert<int>>);
+static_assert(std::same_as<arg_convert<decltype(y), 0, shared_ptr_traits>, v8pp::convert<int>>);
 
-static_assert(std::is_same<arg_convert<decltype(z), 1, raw_ptr_traits>, v8pp::convert<int>>::value, "y(int)");
-static_assert(std::is_same<arg_convert<decltype(z), 1, shared_ptr_traits>, v8pp::convert<int>>::value, "y(int)");
+static_assert(std::same_as<arg_convert<decltype(z), 1, raw_ptr_traits>, v8pp::convert<int>>);
+static_assert(std::same_as<arg_convert<decltype(z), 1, shared_ptr_traits>, v8pp::convert<int>>);
 
 // cv arg converters
 static void s(std::string, std::vector<int>&, std::shared_ptr<int> const&, std::string*, std::string const*) {}
 
-static_assert(std::is_same<arg_convert<decltype(s), 0, raw_ptr_traits>, v8pp::convert<std::string>>::value, "s(string)");
-static_assert(std::is_same<arg_convert<decltype(s), 0, shared_ptr_traits>, v8pp::convert<std::string>>::value, "s(string)");
+static_assert(std::same_as<arg_convert<decltype(s), 0, raw_ptr_traits>, v8pp::convert<std::string>>);
+static_assert(std::same_as<arg_convert<decltype(s), 0, shared_ptr_traits>, v8pp::convert<std::string>>);
 
-static_assert(std::is_same<arg_convert<decltype(s), 1, raw_ptr_traits>, v8pp::convert<std::vector<int>>>::value, "s(vector<int>&)");
-static_assert(std::is_same<arg_convert<decltype(s), 1, shared_ptr_traits>, v8pp::convert<std::vector<int>>>::value, "s(vector<int>&)");
+static_assert(std::same_as<arg_convert<decltype(s), 1, raw_ptr_traits>, v8pp::convert<std::vector<int>>>);
+static_assert(std::same_as<arg_convert<decltype(s), 1, shared_ptr_traits>, v8pp::convert<std::vector<int>>>);
 
-static_assert(std::is_same<arg_convert<decltype(s), 2, raw_ptr_traits>, v8pp::convert<std::shared_ptr<int>>>::value, "s(std::shared_ptr<int> const&)");
-static_assert(std::is_same<arg_convert<decltype(s), 2, shared_ptr_traits>, v8pp::convert<std::shared_ptr<int>>>::value, "s(std::shared_ptr<int> const&)");
+static_assert(std::same_as<arg_convert<decltype(s), 2, raw_ptr_traits>, v8pp::convert<std::shared_ptr<int>>>);
+static_assert(std::same_as<arg_convert<decltype(s), 2, shared_ptr_traits>, v8pp::convert<std::shared_ptr<int>>>);
 
-static_assert(std::is_same<arg_convert<decltype(s), 3, raw_ptr_traits>, v8pp::convert<std::string*>>::value, "s(std::string*)");
-static_assert(std::is_same<arg_convert<decltype(s), 3, shared_ptr_traits>, v8pp::convert<std::string*>>::value, "s(std::string*)");
+static_assert(std::same_as<arg_convert<decltype(s), 3, raw_ptr_traits>, v8pp::convert<std::string*>>);
+static_assert(std::same_as<arg_convert<decltype(s), 3, shared_ptr_traits>, v8pp::convert<std::string*>>);
 
-static_assert(std::is_same<arg_convert<decltype(s), 4, raw_ptr_traits>, v8pp::convert<std::string const*>>::value, "s(std::string const*)");
-static_assert(std::is_same<arg_convert<decltype(s), 4, shared_ptr_traits>, v8pp::convert<std::string const*>>::value, "s(std::string const*)");
+static_assert(std::same_as<arg_convert<decltype(s), 4, raw_ptr_traits>, v8pp::convert<std::string const*>>);
+static_assert(std::same_as<arg_convert<decltype(s), 4, shared_ptr_traits>, v8pp::convert<std::string const*>>);
 
 // fundamental types cv arg converters
 static void t(int, char&, bool const&, float*, char const*) {}
 
-static_assert(std::is_same<arg_convert<decltype(t), 0, raw_ptr_traits>, v8pp::convert<int>>::value, "t(int)");
-static_assert(std::is_same<arg_convert<decltype(t), 0, shared_ptr_traits>, v8pp::convert<int>>::value, "t(int)");
+static_assert(std::same_as<arg_convert<decltype(t), 0, raw_ptr_traits>, v8pp::convert<int>>);
+static_assert(std::same_as<arg_convert<decltype(t), 0, shared_ptr_traits>, v8pp::convert<int>>);
 
-static_assert(std::is_same<arg_convert<decltype(t), 1, raw_ptr_traits>, v8pp::convert<char>>::value, "t(char&)");
-static_assert(std::is_same<arg_convert<decltype(t), 1, shared_ptr_traits>, v8pp::convert<char>>::value, "t(char&)");
+static_assert(std::same_as<arg_convert<decltype(t), 1, raw_ptr_traits>, v8pp::convert<char>>);
+static_assert(std::same_as<arg_convert<decltype(t), 1, shared_ptr_traits>, v8pp::convert<char>>);
 
-static_assert(std::is_same<arg_convert<decltype(t), 2, raw_ptr_traits>, v8pp::convert<bool>>::value, "t(bool const&)");
-static_assert(std::is_same<arg_convert<decltype(t), 2, shared_ptr_traits>, v8pp::convert<bool>>::value, "t(bool const&)");
+static_assert(std::same_as<arg_convert<decltype(t), 2, raw_ptr_traits>, v8pp::convert<bool>>);
+static_assert(std::same_as<arg_convert<decltype(t), 2, shared_ptr_traits>, v8pp::convert<bool>>);
 
-static_assert(std::is_same<arg_convert<decltype(t), 3, raw_ptr_traits>, v8pp::convert<float*>>::value, "t(float*)");
-static_assert(std::is_same<arg_convert<decltype(t), 3, shared_ptr_traits>, v8pp::convert<float*>>::value, "t(float*)");
+static_assert(std::same_as<arg_convert<decltype(t), 3, raw_ptr_traits>, v8pp::convert<float*>>);
+static_assert(std::same_as<arg_convert<decltype(t), 3, shared_ptr_traits>, v8pp::convert<float*>>);
 
-static_assert(std::is_same<arg_convert<decltype(t), 4, raw_ptr_traits>, v8pp::convert<char const*>>::value, "t(char const*)");
-static_assert(std::is_same<arg_convert<decltype(t), 4, shared_ptr_traits>, v8pp::convert<char const*>>::value, "t(char const*)");
+static_assert(std::same_as<arg_convert<decltype(t), 4, raw_ptr_traits>, v8pp::convert<char const*>>);
+static_assert(std::same_as<arg_convert<decltype(t), 4, shared_ptr_traits>, v8pp::convert<char const*>>);
 
 void test_call_from_v8()
 {

--- a/test/test_class.cpp
+++ b/test/test_class.cpp
@@ -324,7 +324,7 @@ void test_class_()
 	context.isolate()->RequestGarbageCollectionForTesting(
 		v8::Isolate::GarbageCollectionType::kFullGarbageCollection);
 
-	bool const use_shared_ptr = std::is_same<Traits, v8pp::shared_ptr_traits>::value;
+	bool constexpr use_shared_ptr = std::same_as<Traits, v8pp::shared_ptr_traits>;
 
 	check_eq("Y count after GC", Y::instance_count,
 		1 + 2 * use_shared_ptr); // y1 + (y2 + y3 when use_shared_ptr)

--- a/test/test_class.cpp
+++ b/test/test_class.cpp
@@ -190,10 +190,10 @@ void test_class_()
 		.static_("my_static_const_var", 42, true)
 		;
 
-	static_assert(std::is_move_constructible<decltype(X_class)>::value, "");
-	static_assert(!std::is_move_assignable<decltype(X_class)>::value, "");
-	static_assert(!std::is_copy_assignable<decltype(X_class)>::value, "");
-	static_assert(!std::is_copy_constructible<decltype(X_class)>::value, "");
+	static_assert(std::is_move_constructible_v<decltype(X_class)>);
+	static_assert(!std::is_move_assignable_v<decltype(X_class)>);
+	static_assert(!std::is_copy_assignable_v<decltype(X_class)>);
+	static_assert(!std::is_copy_constructible_v<decltype(X_class)>);
 
 	v8pp::class_<Y, Traits> Y_class(isolate);
 	Y_class

--- a/test/test_context.cpp
+++ b/test/test_context.cpp
@@ -6,10 +6,10 @@
 
 #include <type_traits>
 
-static_assert(std::is_move_constructible<v8pp::context>::value, "");
-static_assert(std::is_move_assignable<v8pp::context>::value, "");
-static_assert(!std::is_copy_assignable<v8pp::context>::value, "");
-static_assert(!std::is_copy_constructible<v8pp::context>::value, "");
+static_assert(std::is_move_constructible_v<v8pp::context>);
+static_assert(std::is_move_assignable_v<v8pp::context>);
+static_assert(!std::is_copy_assignable_v<v8pp::context>);
+static_assert(!std::is_copy_constructible_v<v8pp::context>);
 
 void test_context()
 {

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -220,12 +220,12 @@ void check_range(v8::Isolate* isolate)
 
 	T zero{ 0 };
 	T min, max;
-	if constexpr (std::is_same_v<T, int64_t>)
+	if constexpr (std::same_as<T, int64_t>)
 	{
 		min = V8_MIN_INT;
 		max = V8_MAX_INT;
 	}
-	else if constexpr (std::is_same_v<T, uint64_t>)
+	else if constexpr (std::same_as<T, uint64_t>)
 	{
 		min = 0;
 		max = V8_MAX_INT;

--- a/test/test_module.cpp
+++ b/test/test_module.cpp
@@ -14,10 +14,10 @@ static int x = 1;
 static int get_x() { return x + 1; }
 static void set_x(int v) { x = v - 1; }
 
-static_assert(std::is_move_constructible<v8pp::module>::value, "");
-static_assert(std::is_move_assignable<v8pp::module>::value, "");
-static_assert(!std::is_copy_assignable<v8pp::module>::value, "");
-static_assert(!std::is_copy_constructible<v8pp::module>::value, "");
+static_assert(std::is_move_constructible_v<v8pp::module>);
+static_assert(std::is_move_assignable_v<v8pp::module>);
+static_assert(!std::is_copy_assignable_v<v8pp::module>);
+static_assert(!std::is_copy_constructible_v<v8pp::module>);
 
 void test_module()
 {

--- a/test/test_ptr_traits.cpp
+++ b/test/test_ptr_traits.cpp
@@ -120,15 +120,15 @@ void test_raw_ptr_traits()
 	X x;
 	traits::pointer_type ptr = &x;
 
-	static_assert(std::is_same<traits::pointer_type, void*>::value, "raw pointer_type");
-	static_assert(std::is_same<traits::const_pointer_type, void const*>::value, "raw const_pointer_type");
+	static_assert(std::same_as<traits::pointer_type, void*>);
+	static_assert(std::same_as<traits::const_pointer_type, void const*>);
 
-	static_assert(std::is_same<traits::object_pointer_type<X>, X*>::value, "raw object_pointer_type");
-	static_assert(std::is_same<traits::object_const_pointer_type<X>, X const*>::value, "raw object_const_pointer_type");
+	static_assert(std::same_as<traits::object_pointer_type<X>, X*>);
+	static_assert(std::same_as<traits::object_const_pointer_type<X>, X const*>);
 
-	static_assert(std::is_same<traits::object_id, void*>::value, "raw object_id");
-	static_assert(std::is_same<traits::convert_ptr<X>, v8pp::convert<X*>>::value, "raw convert_ptr");
-	static_assert(std::is_same<traits::convert_ref<X>, v8pp::convert<X&>>::value, "raw convert_ref");
+	static_assert(std::same_as<traits::object_id, void*>);
+	static_assert(std::same_as<traits::convert_ptr<X>, v8pp::convert<X*>>);
+	static_assert(std::same_as<traits::convert_ref<X>, v8pp::convert<X&>>);
 
 	traits::object_id id = traits::pointer_id(ptr);
 	check_eq("raw_ptr_traits::pointer_id", id, &x);
@@ -145,15 +145,15 @@ void test_shared_ptr_traits()
 	std::shared_ptr<Y> y(Y::make(1), Y::done);
 	traits::pointer_type ptr = y;
 
-	static_assert(std::is_same<traits::pointer_type, std::shared_ptr<void>>::value, "shared pointer_type");
-	static_assert(std::is_same<traits::const_pointer_type, std::shared_ptr<void const>>::value, "shared const_pointer_type");
+	static_assert(std::same_as<traits::pointer_type, std::shared_ptr<void>>);
+	static_assert(std::same_as<traits::const_pointer_type, std::shared_ptr<void const>>);
 
-	static_assert(std::is_same<traits::object_pointer_type<Y>, std::shared_ptr<Y>>::value, "shared object_pointer_type");
-	static_assert(std::is_same<traits::object_const_pointer_type<Y>, std::shared_ptr<Y const>>::value, "shared object_const_pointer_type");
+	static_assert(std::same_as<traits::object_pointer_type<Y>, std::shared_ptr<Y>>);
+	static_assert(std::same_as<traits::object_const_pointer_type<Y>, std::shared_ptr<Y const>>);
 
-	static_assert(std::is_same<traits::object_id, void*>::value, "shared object_id");
-	static_assert(std::is_same<traits::convert_ptr<Y>, v8pp::convert<std::shared_ptr<Y>>>::value, "shared convert_ptr");
-	static_assert(std::is_same<traits::convert_ref<Y>, v8pp::convert<Y, v8pp::ref_from_shared_ptr>>::value, "shared convert_ref");
+	static_assert(std::same_as<traits::object_id, void*>);
+	static_assert(std::same_as<traits::convert_ptr<Y>, v8pp::convert<std::shared_ptr<Y>>>);
+	static_assert(std::same_as<traits::convert_ref<Y>, v8pp::convert<Y, v8pp::ref_from_shared_ptr>>);
 
 	traits::object_id id = traits::pointer_id(ptr);
 	check_eq("shared_ptr_traits::pointer_id", id, y.get());

--- a/test/test_utility.cpp
+++ b/test/test_utility.cpp
@@ -10,14 +10,14 @@ template<typename Ret, typename F>
 void test_ret(F&&)
 {
 	using R = typename v8pp::detail::function_traits<F>::return_type;
-	static_assert(std::is_same<Ret, R>::value, "wrong return_type");
+	static_assert(std::same_as<Ret, R>);
 }
 
 template<typename ArgsTuple, typename F>
 void test_args(F&&)
 {
 	using Args = typename v8pp::detail::function_traits<F>::arguments;
-	static_assert(std::is_same<ArgsTuple, Args>::value, "wrong arguments");
+	static_assert(std::same_as<ArgsTuple, Args>);
 }
 
 template<typename Ret, typename Derived, typename F>
@@ -134,9 +134,9 @@ void test_tuple_tail()
 {
 	using v8pp::detail::tuple_tail;
 
-	static_assert(std::is_same<tuple_tail<std::tuple<int>>::type, std::tuple<>>::value, "");
-	static_assert(std::is_same<tuple_tail<std::tuple<int, char>>::type, std::tuple<char>>::value, "");
-	static_assert(std::is_same<tuple_tail<std::tuple<int, char, bool>>::type, std::tuple<char, bool>>::value, "");
+	static_assert(std::same_as<tuple_tail<std::tuple<int>>::type, std::tuple<>>);
+	static_assert(std::same_as<tuple_tail<std::tuple<int, char>>::type, std::tuple<char>>);
+	static_assert(std::same_as<tuple_tail<std::tuple<int, char, bool>>::type, std::tuple<char, bool>>);
 }
 
 int f() { return 1; }

--- a/v8pp/call_from_v8.hpp
+++ b/v8pp/call_from_v8.hpp
@@ -15,11 +15,10 @@ template<typename F, size_t Offset = 0>
 struct call_from_v8_traits
 {
 	static constexpr size_t offset = Offset;
-	static constexpr bool is_mem_fun = std::is_member_function_pointer<F>::value;
+	static constexpr bool is_mem_fun = std::is_member_function_pointer_v<F>;
 	using arguments = typename function_traits<F>::arguments;
 
-	static constexpr size_t arg_count =
-		std::tuple_size<arguments>::value - is_mem_fun - offset;
+	static constexpr size_t arg_count = std::tuple_size_v<arguments> - is_mem_fun - offset;
 
 	template<size_t Index, bool>
 	struct tuple_element

--- a/v8pp/call_from_v8.hpp
+++ b/v8pp/call_from_v8.hpp
@@ -56,11 +56,11 @@ struct call_from_v8_traits
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_direct_args = CallTraits::arg_count == (Offset + 1) &&
-	std::is_same_v<typename CallTraits::template arg_type<Offset>, v8::FunctionCallbackInfo<v8::Value> const&>;
+	std::same_as<typename CallTraits::template arg_type<Offset>, v8::FunctionCallbackInfo<v8::Value> const&>;
 
 template<typename F, size_t Offset = 0, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_first_arg_isolate = CallTraits::arg_count != (Offset + 0) &&
-	std::is_same_v<typename CallTraits::template arg_type<Offset>, v8::Isolate*>;
+	std::same_as<typename CallTraits::template arg_type<Offset>, v8::Isolate*>;
 
 template<typename Traits, typename F, typename CallTraits, size_t... Indices, typename... ObjArg>
 decltype(auto) call_from_v8_impl(F&& func, v8::FunctionCallbackInfo<v8::Value> const& args,

--- a/v8pp/call_from_v8.hpp
+++ b/v8pp/call_from_v8.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_CALL_FROM_V8_HPP_INCLUDED
-#define V8PP_CALL_FROM_V8_HPP_INCLUDED
+#pragma once
 
 #include <functional>
 #include <utility>
@@ -112,5 +111,3 @@ decltype(auto) call_from_v8(F&& func, v8::FunctionCallbackInfo<v8::Value> const&
 }
 
 } // namespace v8pp::detail
-
-#endif // V8PP_CALL_FROM_V8_HPP_INCLUDED

--- a/v8pp/call_from_v8.hpp
+++ b/v8pp/call_from_v8.hpp
@@ -9,7 +9,7 @@
 #include "v8pp/convert.hpp"
 #include "v8pp/utility.hpp"
 
-namespace v8pp { namespace detail {
+namespace v8pp::detail {
 
 template<typename F, size_t Offset = 0>
 struct call_from_v8_traits
@@ -111,6 +111,6 @@ decltype(auto) call_from_v8(F&& func, v8::FunctionCallbackInfo<v8::Value> const&
 	}
 }
 
-}} // namespace v8pp::detail
+} // namespace v8pp::detail
 
 #endif // V8PP_CALL_FROM_V8_HPP_INCLUDED

--- a/v8pp/call_v8.hpp
+++ b/v8pp/call_v8.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_CALL_V8_HPP_INCLUDED
-#define V8PP_CALL_V8_HPP_INCLUDED
+#pragma once
 
 #include <v8.h>
 
@@ -33,5 +32,3 @@ v8::Local<v8::Value> call_v8(v8::Isolate* isolate, v8::Local<v8::Function> func,
 }
 
 } // namespace v8pp
-
-#endif // V8PP_CALL_V8_HPP_INCLUDED

--- a/v8pp/class.cpp
+++ b/v8pp/class.cpp
@@ -3,7 +3,7 @@
 #if !V8PP_HEADER_ONLY
 #include "v8pp/class.ipp"
 
-namespace v8pp { namespace detail {
+namespace v8pp::detail {
 
 template
 class object_registry<raw_ptr_traits>;
@@ -33,6 +33,6 @@ template
 object_registry<shared_ptr_traits>& classes::find<shared_ptr_traits>(v8::Isolate* isolate,
 	type_info const& type);
 
-}} // namespace v8pp::detail
+} // namespace v8pp::detail
 
 #endif

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_CLASS_HPP_INCLUDED
-#define V8PP_CLASS_HPP_INCLUDED
+#pragma once
 
 #include <algorithm>
 #include <memory>
@@ -503,5 +502,3 @@ void cleanup(v8::Isolate* isolate);
 #if V8PP_HEADER_ONLY
 #include "v8pp/class.ipp"
 #endif
-
-#endif // V8PP_CLASS_HPP_INCLUDED

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -13,9 +13,7 @@
 #include "v8pp/ptr_traits.hpp"
 #include "v8pp/type_info.hpp"
 
-namespace v8pp {
-
-namespace detail {
+namespace v8pp::detail {
 
 struct class_info
 {
@@ -140,7 +138,9 @@ private:
 	static classes* instance(operation op, v8::Isolate* isolate);
 };
 
-} // namespace detail
+} // namespace v8pp::detail
+
+namespace v8pp {
 
 /// Interface to access C++ classes bound to V8
 template<typename T, typename Traits = raw_ptr_traits>

--- a/v8pp/class.hpp
+++ b/v8pp/class.hpp
@@ -322,7 +322,7 @@ public:
 			|| detail::is_callable<Getter>::value, "GetFunction must be callable");
 		static_assert(std::is_member_function_pointer<SetFunction>::value
 			|| detail::is_callable<Setter>::value
-			|| std::is_same<Setter, detail::none>::value, "SetFunction must be callable");
+			|| std::same_as<Setter, detail::none>, "SetFunction must be callable");
 
 		using GetClass = std::conditional_t<detail::function_with_object<Getter, T>, T, detail::none>;
 		using SetClass = std::conditional_t<detail::function_with_object<Setter, T>, T, detail::none>;

--- a/v8pp/class.ipp
+++ b/v8pp/class.ipp
@@ -2,9 +2,7 @@
 
 #include <cstdio> // for snprintf
 
-namespace v8pp {
-
-namespace detail {
+namespace v8pp::detail {
 
 static V8PP_IMPL std::string pointer_str(void const* ptr)
 {
@@ -417,7 +415,9 @@ V8PP_IMPL classes* classes::instance(operation op, v8::Isolate* isolate)
 	return nullptr; // should never reach this line
 }
 
-} // namespace detail
+} // namespace v8pp::detail
+
+namespace v8pp {
 
 V8PP_IMPL void cleanup(v8::Isolate* isolate)
 {

--- a/v8pp/class.ipp
+++ b/v8pp/class.ipp
@@ -1,5 +1,6 @@
 #include "v8pp/class.hpp"
 
+#include <cassert>
 #include <cstdio> // for snprintf
 
 namespace v8pp::detail {

--- a/v8pp/config.hpp.in
+++ b/v8pp/config.hpp.in
@@ -1,5 +1,4 @@
-#ifndef V8PP_CONFIG_HPP_INCLUDED
-#define V8PP_CONFIG_HPP_INCLUDED
+#pragma once
 
 /// v8pp library version
 #define V8PP_VERSION "@PROJECT_VERSION@"
@@ -48,5 +47,3 @@ v8::Local<v8::Value> V8PP_PLUGIN_INIT_PROC_NAME(isolate)
 
 #define V8PP_STRINGIZE(s)  V8PP_STRINGIZE0(s)
 #define V8PP_STRINGIZE0(s) #s
-
-#endif // V8PP_CONFIG_HPP_INCLUDED

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -87,7 +87,7 @@ public:
 	template<typename Function, typename Traits = raw_ptr_traits>
 	context& function(std::string_view name, Function&& func)
 	{
-		using Fun = typename std::decay<Function>::type;
+		using Fun = typename std::decay_t<Function>;
 		static_assert(detail::is_callable<Fun>::value, "Function must be callable");
 		return value(name, wrap_function<Function, Traits>(isolate_, name, std::forward<Function>(func)));
 	}

--- a/v8pp/context.hpp
+++ b/v8pp/context.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_CONTEXT_HPP_INCLUDED
-#define V8PP_CONTEXT_HPP_INCLUDED
+#pragma once
 
 #include <string>
 #include <map>
@@ -119,5 +118,3 @@ private:
 };
 
 } // namespace v8pp
-
-#endif // V8PP_CONTEXT_HPP_INCLUDED

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_CONVERT_HPP_INCLUDED
-#define V8PP_CONVERT_HPP_INCLUDED
+#pragma once
 
 #include <v8.h>
 
@@ -905,5 +904,3 @@ inline invalid_argument::invalid_argument(v8::Isolate* isolate, v8::Local<v8::Va
 }
 
 } // namespace v8pp
-
-#endif // V8PP_CONVERT_HPP_INCLUDED

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -687,7 +687,7 @@ struct convert<T, typename std::enable_if<is_wrapped_class<T>::value>::type>
 {
 	using from_type = T&;
 	using to_type = v8::Local<v8::Object>;
-	using class_type = typename std::remove_cv<T>::type;
+	using class_type = typename std::remove_cv_t<T>;
 
 	static bool is_valid(v8::Isolate* isolate, v8::Local<v8::Value> value)
 	{
@@ -721,7 +721,7 @@ struct convert<std::shared_ptr<T>, typename std::enable_if<is_wrapped_class<T>::
 {
 	using from_type = std::shared_ptr<T>;
 	using to_type = v8::Local<v8::Object>;
-	using class_type = typename std::remove_cv<T>::type;
+	using class_type = typename std::remove_cv_t<T>;
 
 	static bool is_valid(v8::Isolate*, v8::Local<v8::Value> value)
 	{
@@ -748,7 +748,7 @@ struct convert<T, ref_from_shared_ptr>
 {
 	using from_type = T&;
 	using to_type = v8::Local<v8::Object>;
-	using class_type = typename std::remove_cv<T>::type;
+	using class_type = typename std::remove_cv_t<T>;
 
 	static bool is_valid(v8::Isolate* isolate, v8::Local<v8::Value> value)
 	{

--- a/v8pp/convert.hpp
+++ b/v8pp/convert.hpp
@@ -409,7 +409,7 @@ private:
 	static void get_number(v8::Isolate* isolate, v8::Local<v8::Value> value, std::optional<from_type>& result)
 	{
 		Number const number = v8pp::convert<Number>::from_v8(isolate, value);
-		if constexpr (std::is_same_v<T, uint64_t>)
+		if constexpr (std::same_as<T, uint64_t>)
 		{
 			result = static_cast<T>(number);
 		}

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -162,7 +162,7 @@ void forward_function(v8::FunctionCallbackInfo<v8::Value> const& args)
 	v8::HandleScope scope(isolate);
 	try
 	{
-		if constexpr (std::is_same_v<typename FTraits::return_type, void>)
+		if constexpr (std::same_as<typename FTraits::return_type, void>)
 		{
 			invoke<Traits, F, FTraits>(args);
 		}

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_FUNCTION_HPP_INCLUDED
-#define V8PP_FUNCTION_HPP_INCLUDED
+#pragma once
 
 #include <cstring> // for memcpy
 
@@ -210,5 +209,3 @@ v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view nam
 }
 
 } // namespace v8pp
-
-#endif // V8PP_FUNCTION_HPP_INCLUDED

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -10,7 +10,7 @@
 #include "v8pp/throw_ex.hpp"
 #include "v8pp/utility.hpp"
 
-namespace v8pp { namespace detail {
+namespace v8pp::detail {
 
 class external_data
 {
@@ -178,7 +178,9 @@ void forward_function(v8::FunctionCallbackInfo<v8::Value> const& args)
 	}
 }
 
-} // namespace detail
+} // namespace v8pp::detail
+
+namespace v8pp {
 
 /// Wrap C++ function into new V8 function template
 template<typename F, typename Traits = raw_ptr_traits>

--- a/v8pp/function.hpp
+++ b/v8pp/function.hpp
@@ -155,8 +155,7 @@ void forward_function(v8::FunctionCallbackInfo<v8::Value> const& args)
 {
 	using FTraits = function_traits<F>;
 
-	static_assert(is_callable<F>::value || std::is_member_function_pointer<F>::value,
-		"required callable F");
+	static_assert(is_callable<F>::value || std::is_member_function_pointer_v<F>, "required callable F");
 
 	v8::Isolate* isolate = args.GetIsolate();
 	v8::HandleScope scope(isolate);
@@ -185,7 +184,7 @@ void forward_function(v8::FunctionCallbackInfo<v8::Value> const& args)
 template<typename F, typename Traits = raw_ptr_traits>
 v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate, F&& func)
 {
-	using F_type = typename std::decay<F>::type;
+	using F_type = typename std::decay_t<F>;
 	return v8::FunctionTemplate::New(isolate,
 		&detail::forward_function<Traits, F_type>,
 		detail::external_data::set(isolate, std::forward<F_type>(func)));
@@ -197,7 +196,7 @@ v8::Local<v8::FunctionTemplate> wrap_function_template(v8::Isolate* isolate, F&&
 template<typename F, typename Traits = raw_ptr_traits>
 v8::Local<v8::Function> wrap_function(v8::Isolate* isolate, std::string_view name, F&& func)
 {
-	using F_type = typename std::decay<F>::type;
+	using F_type = typename std::decay_t<F>;
 	v8::Local<v8::Function> fn = v8::Function::New(isolate->GetCurrentContext(),
 		&detail::forward_function<Traits, F_type>,
 		detail::external_data::set(isolate, std::forward<F_type>(func))).ToLocalChecked();

--- a/v8pp/json.hpp
+++ b/v8pp/json.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_JSON_HPP_INCLUDED
-#define V8PP_JSON_HPP_INCLUDED
+#pragma once
 
 #include <string>
 
@@ -29,5 +28,3 @@ v8::Local<v8::Object> json_object(v8::Isolate* isolate, v8::Local<v8::Object> ob
 #if V8PP_HEADER_ONLY
 #include "v8pp/json.ipp"
 #endif
-
-#endif // V8PP_JSON_HPP_INCLUDED

--- a/v8pp/module.hpp
+++ b/v8pp/module.hpp
@@ -69,7 +69,7 @@ public:
 	template<typename Function, typename Traits = raw_ptr_traits>
 	module& function(std::string_view name, Function&& func)
 	{
-		using Fun = typename std::decay<Function>::type;
+		using Fun = typename std::decay_t<Function>;
 		static_assert(detail::is_callable<Fun>::value, "Function must be callable");
 		return value(name, wrap_function_template<Function, Traits>(isolate_, std::forward<Function>(func)));
 	}
@@ -93,8 +93,9 @@ public:
 	template<typename GetFunction, typename SetFunction = detail::none>
 	module& property(char const* name, GetFunction&& get, SetFunction&& set = {})
 	{
-		using Getter = typename std::decay<GetFunction>::type;
-		using Setter = typename std::decay<SetFunction>::type;
+		using Getter = typename std::decay_t<GetFunction>;
+		using Setter = typename std::decay_t<SetFunction>;
+
 		static_assert(detail::is_callable<Getter>::value, "GetFunction must be callable");
 		static_assert(detail::is_callable<Setter>::value
 			|| std::same_as<Setter, detail::none>, "SetFunction must be callable");

--- a/v8pp/module.hpp
+++ b/v8pp/module.hpp
@@ -97,7 +97,7 @@ public:
 		using Setter = typename std::decay<SetFunction>::type;
 		static_assert(detail::is_callable<Getter>::value, "GetFunction must be callable");
 		static_assert(detail::is_callable<Setter>::value
-			|| std::is_same<Setter, detail::none>::value, "SetFunction must be callable");
+			|| std::same_as<Setter, detail::none>, "SetFunction must be callable");
 
 		using property_type = v8pp::property<Getter, Setter, detail::none, detail::none>;
 		using Traits = detail::none;

--- a/v8pp/module.hpp
+++ b/v8pp/module.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_MODULE_HPP_INCLUDED
-#define V8PP_MODULE_HPP_INCLUDED
+#pragma once
 
 #include <v8.h>
 
@@ -164,5 +163,3 @@ private:
 };
 
 } // namespace v8pp
-
-#endif // V8PP_MODULE_HPP_INCLUDED

--- a/v8pp/object.hpp
+++ b/v8pp/object.hpp
@@ -1,7 +1,6 @@
-#ifndef V8PP_OBJECT_HPP_INCLUDED
-#define V8PP_OBJECT_HPP_INCLUDED
+#pragma once
 
-#include <cstring>
+#include <string_view>
 
 #include <v8.h>
 
@@ -62,5 +61,3 @@ void set_const(v8::Isolate* isolate, v8::Local<v8::Object> options,
 }
 
 } // namespace v8pp
-
-#endif // V8PP_OBJECT_HPP_INCLUDED

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -6,12 +6,7 @@
 #include "v8pp/convert.hpp"
 #include "v8pp/function.hpp"
 
-namespace v8pp {
-
-template<typename Get, typename Set, typename GetClass, typename SetClass>
-struct property;
-
-namespace detail {
+namespace v8pp::detail {
 
 template<typename F, typename T, typename U = typename call_from_v8_traits<F>::template arg_type<0>>
 inline constexpr bool function_with_object = std::is_member_function_pointer_v<F> ||
@@ -164,7 +159,9 @@ catch (std::exception const& ex)
 	// TODO: info.GetReturnValue().Set(false);
 }
 
-} // namespace detail
+} // namespace v8pp::detail
+
+namespace v8pp {
 
 /// Property with get and set functions
 template<typename Get, typename Set, typename GetClass, typename SetClass>

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -1,7 +1,4 @@
-#ifndef V8PP_PROPERTY_HPP_INCLUDED
-#define V8PP_PROPERTY_HPP_INCLUDED
-
-#include <cassert>
+#pragma once
 
 #include "v8pp/convert.hpp"
 #include "v8pp/function.hpp"
@@ -226,5 +223,3 @@ struct property<Get, detail::none, GetClass, detail::none> final
 };
 
 } // namespace v8pp
-
-#endif // V8PP_PROPERTY_HPP_INCLUDED

--- a/v8pp/property.hpp
+++ b/v8pp/property.hpp
@@ -18,18 +18,19 @@ inline constexpr bool function_with_object = std::is_member_function_pointer_v<F
 	(std::is_lvalue_reference_v<U> && std::is_base_of_v<T, std::remove_cv_t<std::remove_reference_t<U>>>);
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
-inline constexpr bool is_getter = CallTraits::arg_count == 0 + Offset && !is_void_return<F>;
+inline constexpr bool is_getter = CallTraits::arg_count == 0 + Offset
+	&& !std::same_as<typename function_traits<F>::return_type, void>;
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_direct_getter = CallTraits::arg_count == 2 + Offset
 	&& std::is_convertible_v<typename CallTraits::template arg_type<0 + Offset>, v8::Local<v8::Name>>
-	&& std::is_same_v<typename CallTraits::template arg_type<1 + Offset>, v8::PropertyCallbackInfo<v8::Value> const&>
-	&& is_void_return<F>;
+	&& std::same_as<typename CallTraits::template arg_type<1 + Offset>, v8::PropertyCallbackInfo<v8::Value> const&>
+	&& std::same_as<typename function_traits<F>::return_type, void>;
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_isolate_getter = CallTraits::arg_count == 1 + Offset
 	&& is_first_arg_isolate<F, Offset>
-	&& !is_void_return<F>;
+	&& !std::same_as<typename function_traits<F>::return_type, void>;
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_setter = CallTraits::arg_count == 1 + Offset;
@@ -37,9 +38,9 @@ inline constexpr bool is_setter = CallTraits::arg_count == 1 + Offset;
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_direct_setter = CallTraits::arg_count == 3 + Offset
 	&& std::is_convertible_v<typename CallTraits::template arg_type<0 + Offset>, v8::Local<v8::Name>>
-	&& std::is_same_v<typename CallTraits::template arg_type<1 + Offset>, v8::Local<v8::Value>>
-	&& std::is_same_v<typename CallTraits::template arg_type<2 + Offset>, v8::PropertyCallbackInfo<void> const&>
-	&& is_void_return<F>;
+	&& std::same_as<typename CallTraits::template arg_type<1 + Offset>, v8::Local<v8::Value>>
+	&& std::same_as<typename CallTraits::template arg_type<2 + Offset>, v8::PropertyCallbackInfo<void> const&>
+	&& std::same_as<typename function_traits<F>::return_type, void>;
 
 template<typename F, size_t Offset, typename CallTraits = call_from_v8_traits<F>>
 inline constexpr bool is_isolate_setter = CallTraits::arg_count == 2 + Offset
@@ -120,7 +121,7 @@ try
 {
 	auto&& property = detail::external_data::get<Property>(info.Data());
 
-	if constexpr (std::is_same_v<GetClass, none>)
+	if constexpr (std::same_as<GetClass, none>)
 	{
 		property_get(property.getter, name, info);
 	}
@@ -144,7 +145,7 @@ try
 {
 	auto&& property = detail::external_data::get<Property>(info.Data());
 
-	if constexpr (std::is_same_v<SetClass, none>)
+	if constexpr (std::same_as<SetClass, none>)
 	{
 		property_set(property.setter, name, value, info);
 	}

--- a/v8pp/ptr_traits.hpp
+++ b/v8pp/ptr_traits.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_PTR_TRAITS_HPP_INCLUDED
-#define V8PP_PTR_TRAITS_HPP_INCLUDED
+#pragma once
 
 #include <memory>
 
@@ -111,5 +110,3 @@ struct shared_ptr_traits
 };
 
 } //namespace v8pp
-
-#endif // V8PP_PTR_TRAITS_HPP_INCLUDED

--- a/v8pp/throw_ex.hpp
+++ b/v8pp/throw_ex.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_THROW_EX_HPP_INCLUDED
-#define V8PP_THROW_EX_HPP_INCLUDED
+#pragma once
 
 #include <string_view>
 
@@ -35,5 +34,3 @@ v8::Local<v8::Value> throw_type_error(v8::Isolate* isolate, std::string_view mes
 #if V8PP_HEADER_ONLY
 #include "v8pp/throw_ex.ipp"
 #endif
-
-#endif // V8PP_THROW_EX_HPP_INCLUDED

--- a/v8pp/type_info.hpp
+++ b/v8pp/type_info.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_TYPE_INFO_HPP_INCLUDED
-#define V8PP_TYPE_INFO_HPP_INCLUDED
+#pragma once
 
 #include <string_view>
 
@@ -64,5 +63,3 @@ constexpr type_info type_id()
 }
 
 } // namespace v8pp::detail
-
-#endif // V8PP_TYPE_INFO_HPP_INCLUDED

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -302,9 +302,6 @@ struct function_traits<F&&> : function_traits<F>
 {
 };
 
-template<typename F>
-inline constexpr bool is_void_return = std::is_same_v<void, typename function_traits<F>::return_type>;
-
 template<typename F, bool is_class>
 struct is_callable_impl
 	: std::is_function<typename std::remove_pointer<F>::type>

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -9,7 +9,7 @@
 #include <tuple>
 #include <type_traits>
 
-namespace v8pp { namespace detail {
+namespace v8pp::detail {
 
 template<typename T>
 struct tuple_tail;
@@ -334,6 +334,6 @@ template<typename F>
 using is_callable = std::integral_constant<bool,
 	is_callable_impl<F, std::is_class<F>::value>::value>;
 
-}} // namespace v8pp::detail
+} // namespace v8pp::detail
 
 #endif // V8PP_UTILITY_HPP_INCLUDED

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -1,6 +1,7 @@
 #ifndef V8PP_UTILITY_HPP_INCLUDED
 #define V8PP_UTILITY_HPP_INCLUDED
 
+#include <concepts>
 #include <functional>
 #include <memory>
 #include <string>
@@ -22,6 +23,9 @@ struct tuple_tail<std::tuple<Head, Tail...>>
 struct none
 {
 };
+
+template<typename Char>
+concept WideChar = std::same_as<Char, char16_t> || std::same_as<Char, char32_t> || std::same_as<Char, wchar_t>;
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/v8pp/utility.hpp
+++ b/v8pp/utility.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_UTILITY_HPP_INCLUDED
-#define V8PP_UTILITY_HPP_INCLUDED
+#pragma once
 
 #include <concepts>
 #include <functional>
@@ -335,5 +334,3 @@ using is_callable = std::integral_constant<bool,
 	is_callable_impl<F, std::is_class<F>::value>::value>;
 
 } // namespace v8pp::detail
-
-#endif // V8PP_UTILITY_HPP_INCLUDED

--- a/v8pp/version.hpp
+++ b/v8pp/version.hpp
@@ -1,5 +1,4 @@
-#ifndef V8PP_VERSION_HPP_INCLUDED
-#define V8PP_VERSION_HPP_INCLUDED
+#pragma once
 
 #include "v8pp/config.hpp"
 
@@ -18,5 +17,3 @@ char const* build_options();
 #if V8PP_HEADER_ONLY
 #include "v8pp/version.ipp"
 #endif
-
-#endif // V8PP_VERSION_HPP_INCLUDED


### PR DESCRIPTION
- additional msvc flag for C++20 in CMakeLists.txt
- add concept `v8pp::detail::WideChar`
- use `std::same_as` concept instead of `std::is_same`
- use `std::is_*_v` constexpr bools
- nested `v8pp::detail` declarations
- use #pragma once instead of include guards